### PR TITLE
Update README.md

### DIFF
--- a/contracts/ckb-combine-lock/README.md
+++ b/contracts/ckb-combine-lock/README.md
@@ -1,7 +1,7 @@
 
 
 ### Build
-There are 2 options:
+There are 3 options:
 1. use capsule at root folder:
 ```
 capsule build
@@ -13,6 +13,12 @@ Suggested for production usage for sake of reproducible build.
 rustup target add riscv64imac-unknown-none-elf
 sudo apt install gcc-riscv64-unknown-elf
 cargo build --release --target riscv64imac-unknown-none-elf
+```
+3. use nix command
+```
+sh <(curl -L https://nixos.org/nix/install) --daemon --yes
+rustup target add riscv64imac-unknown-none-elf
+CC_riscv64imac_unknown_none_elf="$(nix build --print-out-paths --no-link "nixpkgs#pkgsCross.riscv64-embedded.stdenv.cc.out" 2>/dev/null)/bin/riscv64-none-elf-gcc" cargo build --release --target=riscv64imac-unknown-none-elf
 ```
 Suggested for developing phase.
 


### PR DESCRIPTION
Build by option 2, use native compiler exits problem: 
Attempted to execute and encountered an error indicating that the stdint.h header file was missing when using the native compiler. The command "riscv64-unknown-elf-gcc" did not execute successfully (status code exit status: 1).

The error message displayed:

running: "riscv64-unknown-elf-gcc" "-O3" "-ffunction-sections" "-fdata-sections" "-march=rv64imac" "-mabi=lp64" "-mcmodel=medany" "-Wall" "-Wextra" "-o" "/workspace/ckb-combine-lock-poc/target/riscv64imac-unknown-none-elf/release/build/blake2b-rs-5e7a969012c3c223/out/BLAKE2/ref/blake2b-ref.o" "-c" "BLAKE2/ref/blake2b-ref.c" cargo:warning=In file included from BLAKE2/ref/blake2b-ref.c:16: cargo:warning=/usr/lib/gcc/riscv64-unknown-elf/10.2.0/include/stdint.h:9:16: fatal error: stdint.h: No such file or directory
cargo:warning=    9 | # include_next <stdint.h>
cargo:warning=      |                ^~~~~~
cargo:warning=compilation terminated.
exit status: 1

--- stderr

The operating system environment used was Ubuntu with kernel version 5.15.0-47-generic.

To reproduce the issue, the following steps were taken:

rustup target add riscv64imac-unknown-none-elf
sudo apt install gcc-riscv64-unknown-elf
cargo build --release --target riscv64imac-unknown-none-elf