### PR TITLE
Auto complete trivial fields in tx.json

### DIFF
--- a/ckb-debugger-tests/src/auto_complete.rs
+++ b/ckb-debugger-tests/src/auto_complete.rs
@@ -1,0 +1,94 @@
+use anyhow::anyhow;
+use serde_json::{json, Value};
+
+static mut NONCE: u32 = 0;
+
+/* generate a pseudo unique out point:
+{
+    "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000005",
+    "index": "0x0"
+}
+*/
+fn gen_outpoint() -> Value {
+    let tx_hash = unsafe {
+        let r = format!(
+            "0x000000000000000000000000000000000000000000000000000000000000{:04X}",
+            NONCE
+        );
+        NONCE += 1;
+        r
+    };
+    json!({"tx_hash": tx_hash, "index": "0x0"})
+}
+
+/* generate a pseudo unique cell_dep:
+{
+    "out_point": {
+        "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000005",
+        "index": "0x0"
+    },
+    "dep_type": "code"
+}
+*/
+fn gen_celldep() -> Value {
+    json!({
+        "out_point": gen_outpoint(),
+        "dep_type": "code"
+    })
+}
+
+/* generate a pseudo unique input */
+fn gen_input() -> Value {
+    json!({
+        "previous_output": gen_outpoint(),
+        "since": "0x0"
+    })
+}
+
+fn fill_missing(root: &mut Value, child: &str, name: &str, value: Value) {
+    let pointer = format!("/{}/{}", child, name);
+    let node = root.pointer(&pointer);
+    if node.is_none() {
+        root[child][name] = value
+    }
+}
+
+pub fn auto_complete(mock_tx: &str) -> Result<String, anyhow::Error> {
+    let mut root: Value = serde_json::from_str(mock_tx)?;
+
+    fill_missing(&mut root, "tx", "version", json!("0x0"));
+    fill_missing(&mut root, "tx", "cell_deps", json!([]));
+    fill_missing(&mut root, "tx", "header_deps", json!([]));
+    fill_missing(&mut root, "tx", "inputs", json!([]));
+    fill_missing(&mut root, "mock_info", "header_deps", json!([]));
+
+    let mut index = 0;
+    #[allow(while_true)]
+    while true {
+        let pointer = format!("/mock_info/cell_deps/{}", index);
+        if let Some(cell_dep) = root.pointer_mut(&pointer) {
+            if cell_dep.get("cell_dep").is_none() {
+                cell_dep["cell_dep"] = gen_celldep();
+            }
+        } else {
+            break;
+        }
+        index += 1;
+    }
+
+    let mut index = 0;
+    #[allow(while_true)]
+    while true {
+        let pointer = format!("/mock_info/inputs/{}", index);
+        if let Some(input) = root.pointer_mut(&pointer) {
+            if input.get("input").is_none() {
+                input["input"] = gen_input();
+            }
+        } else {
+            break;
+        }
+        index += 1;
+    }
+
+    serde_json::to_string_pretty(&root).map_err(|e| anyhow!(e))
+}

--- a/ckb-debugger-tests/templates/always-success.json
+++ b/ckb-debugger-tests/templates/always-success.json
@@ -1,70 +1,50 @@
 {
-    "mock_info": {
-      "inputs": [
-        {
-          "input": {
-            "previous_output": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-              "index": "0x0"
-            },
-            "since": "0x0"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x",
-              "code_hash": "0x{{ ref_type always_success }}",
-              "hash_type": "type"
-            },
-            "type": null
-          },
-          "data": "0x"
-        }
-      ],
-      "cell_deps": [
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type always_success }}"
-          },
-          "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-always-success }}"
-        }
-      ],
-      "header_deps": []
-    },
-    "tx": {
-      "version": "0x0",
-      "cell_deps": [ ],
-      "header_deps": [],
-      "inputs": [],
-      "outputs": [
-        {
-          "capacity": "0x0",
+  "mock_info": {
+    "inputs": [
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x",
             "code_hash": "0x{{ ref_type always_success }}",
             "hash_type": "type"
-          }
+          },
+          "type": null
+        },
+        "data": "0x"
+      }
+    ],
+    "cell_deps": [
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type always_success }}"
+        },
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-always-success }}"
+      }
+    ]
+  },
+  "tx": {
+    "outputs": [
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x",
+          "code_hash": "0x{{ ref_type always_success }}",
+          "hash_type": "type"
         }
-      ],
-      "witnesses": [
-        "0x"
-      ],
-      "outputs_data": [
-        "0x"
-      ]
-    }
+      }
+    ],
+    "witnesses": [
+      "0x"
+    ],
+    "outputs_data": [
+      "0x"
+    ]
   }
-  
+}

--- a/ckb-debugger-tests/templates/child-script-multi-inputs.json
+++ b/ckb-debugger-tests/templates/child-script-multi-inputs.json
@@ -1,248 +1,142 @@
 {
-    "mock_info": {
-      "inputs": [
-        {
-          "input": {
-            "previous_output": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-              "index": "0x0"
-            },
-            "since": "0x0"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-              "code_hash": "0x{{ ref_type child-script-example }}",
-              "hash_type": "type"
-            },
-            "type": null
-          },
-          "data": "0x"
-        },
-        {
-          "input": {
-            "previous_output": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000006",
-              "index": "0x0"
-            },
-            "since": "0x0"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-              "code_hash": "0x{{ ref_type child-script-example }}",
-              "hash_type": "type"
-            },
-            "type": null
-          },
-          "data": "0x"
-        },
-        {
-          "input": {
-            "previous_output": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000007",
-              "index": "0x0"
-            },
-            "since": "0x0"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x00009DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-              "code_hash": "0x{{ ref_type always_success }}",
-              "hash_type": "type"
-            },
-            "type": null
-          },
-          "data": "0x"
-        }
-      ],
-      "cell_deps": [
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type child-script-example }}"
-          },
-          "data": "0x{{ data ../../build/release/child-script-example }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type auth }}"
-          },
-          "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000004",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type secp256k1_data }}"
-          },
-          "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000005",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x",
-              "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-              "hash_type": "data1"
-            },
-            "type": "{{ def_type always_success }}"
-          },
-          "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-always-success }}"
-        }
-      ],
-      "header_deps": []
-    },
-    "tx": {
-      "version": "0x0",
-      "cell_deps": [
-        {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
-        {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
-        {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000004",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
-        {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000005",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        }
-      ],
-      "header_deps": [],
-      "inputs": [
-        {
-          "previous_output": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-            "index": "0x0"
-          },
-          "since": "0x0"
-        },
-        {
-          "previous_output": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000006",
-            "index": "0x0"
-          },
-          "since": "0x0"
-        },
-        {
-          "previous_output": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000007",
-            "index": "0x0"
-          },
-          "since": "0x0"
-        }
-      ],
-      "outputs": [
-        {
-          "capacity": "0x0",
+  "mock_info": {
+    "inputs": [
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
             "code_hash": "0x{{ ref_type child-script-example }}",
             "hash_type": "type"
-          }
+          },
+          "type": null
         },
-        {
-          "capacity": "0x0",
+        "data": "0x"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
             "code_hash": "0x{{ ref_type child-script-example }}",
             "hash_type": "type"
-          }
+          },
+          "type": null
         },
-        {
-          "capacity": "0x0",
+        "data": "0x"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00009DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x{{ ref_type always_success }}",
+            "hash_type": "type"
+          },
+          "type": null
+        },
+        "data": "0x"
+      }
+    ],
+    "cell_deps": [
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-            "code_hash": "0x{{ ref_type child-script-example }}",
-            "hash_type": "type"
-          }
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type child-script-example }}"
         },
-        {
-          "capacity": "0x0",
+        "data": "0x{{ data ../../build/release/child-script-example }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-            "code_hash": "0x{{ ref_type child-script-example }}",
-            "hash_type": "type"
-          }
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type auth }}"
+        },
+        "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type secp256k1_data }}"
+        },
+        "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type always_success }}"
+        },
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-always-success }}"
+      }
+    ]
+  },
+  "tx": {
+    "outputs": [
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type child-script-example }}",
+          "hash_type": "type"
         }
-      ],
-      "witnesses": [
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-      ],
-      "outputs_data": [
-        "0x",
-        "0x",
-        "0x",
-        "0x"
-      ]
-    }
+      },
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type child-script-example }}",
+          "hash_type": "type"
+        }
+      },
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type child-script-example }}",
+          "hash_type": "type"
+        }
+      },
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type child-script-example }}",
+          "hash_type": "type"
+        }
+      }
+    ],
+    "witnesses": [
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000",
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    ],
+    "outputs_data": [
+      "0x",
+      "0x",
+      "0x",
+      "0x"
+    ]
   }
-  
+}

--- a/ckb-debugger-tests/templates/child-script-multisig-success.json
+++ b/ckb-debugger-tests/templates/child-script-multisig-success.json
@@ -2,13 +2,6 @@
   "mock_info": {
     "inputs": [
       {
-        "input": {
-          "since": "0x0",
-          "previous_output": {
-            "index": "0x0",
-            "tx_hash": "0xf77ffe23253b8d6af3d7f918b616286232e0804f495e8fdfffc975d0b2b27f90"
-          }
-        },
         "output": {
           "capacity": "0x2a",
           "lock": {
@@ -23,13 +16,6 @@
     ],
     "cell_deps": [
       {
-        "cell_dep": {
-          "out_point": {
-            "index": "0x0",
-            "tx_hash": "0xe9e8e158d73dae3f4811fa903eb75e1e1b39297bdc22a1584370cd22cd3ee961"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x5b6bc386800",
           "lock": {
@@ -37,18 +23,11 @@
             "hash_type": "data",
             "args": "0x"
           },
-          "type": {{ def_type child-script-example }}
+          "type": "{{ def_type child-script-example }}"
         },
         "data": "0x{{ data ../../build/release/child-script-example }}"
       },
       {
-        "cell_dep": {
-          "out_point": {
-            "index": "0x0",
-            "tx_hash": "0x013b4ed253d017a1bae94debf0414c76b50d20c7395a06582bebb7cafc3e0050"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0xde783cf3000",
           "lock": {
@@ -56,18 +35,11 @@
             "hash_type": "data",
             "args": "0x"
           },
-          "type": {{ def_type auth }}
+          "type": "{{ def_type auth }}"
         },
         "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
       },
       {
-        "cell_dep": {
-          "out_point": {
-            "index": "0x0",
-            "tx_hash": "0x70fd3a1a88a019af76cd31239f0749bffe652ee994b203a4c1c97cf3e99b49ed"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0xbebc20000",
           "lock": {
@@ -75,18 +47,11 @@
             "hash_type": "data",
             "args": "0x"
           },
-          "type": {{ def_type child-script-always-success }}
+          "type": "{{ def_type child-script-always-success }}"
         },
         "data": "0x{{ data ../../build/release/child-script-always-success }}"
       },
       {
-        "cell_dep": {
-          "out_point": {
-            "index": "0x0",
-            "tx_hash": "0xb8690d106df175c39bf31539fc7c5202ff105674e9c879e8027ad7fc724a74f4"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x5f5e10000000",
           "lock": {
@@ -94,55 +59,13 @@
             "hash_type": "data",
             "args": "0x"
           },
-          "type": {{ def_type secp256k1_data }}
+          "type": "{{ def_type secp256k1_data }}"
         },
         "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
       }
-    ],
-    "header_deps": []
+    ]
   },
   "tx": {
-    "version": "0x0",
-    "cell_deps": [
-      {
-        "out_point": {
-          "index": "0x0",
-          "tx_hash": "0xe9e8e158d73dae3f4811fa903eb75e1e1b39297bdc22a1584370cd22cd3ee961"
-        },
-        "dep_type": "code"
-      },
-      {
-        "out_point": {
-          "index": "0x0",
-          "tx_hash": "0x013b4ed253d017a1bae94debf0414c76b50d20c7395a06582bebb7cafc3e0050"
-        },
-        "dep_type": "code"
-      },
-      {
-        "out_point": {
-          "index": "0x0",
-          "tx_hash": "0x70fd3a1a88a019af76cd31239f0749bffe652ee994b203a4c1c97cf3e99b49ed"
-        },
-        "dep_type": "code"
-      },
-      {
-        "out_point": {
-          "index": "0x0",
-          "tx_hash": "0xb8690d106df175c39bf31539fc7c5202ff105674e9c879e8027ad7fc724a74f4"
-        },
-        "dep_type": "code"
-      }
-    ],
-    "header_deps": [],
-    "inputs": [
-      {
-        "since": "0x0",
-        "previous_output": {
-          "index": "0x0",
-          "tx_hash": "0xf77ffe23253b8d6af3d7f918b616286232e0804f495e8fdfffc975d0b2b27f90"
-        }
-      }
-    ],
     "outputs": [
       {
         "capacity": "0x2a",

--- a/ckb-debugger-tests/templates/child-script-success.json
+++ b/ckb-debugger-tests/templates/child-script-success.json
@@ -1,110 +1,74 @@
 {
-    "mock_info": {
-      "inputs": [
-        {
-          "input": {
-            "previous_output": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-              "index": "0x0"
-            },
-            "since": "0x0"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-              "code_hash": "0x{{ ref_type child-script-example }}",
-              "hash_type": "type"
-            },
-            "type": null
-          },
-          "data": "0x"
-        }
-      ],
-      "cell_deps": [
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type child-script-example }}"
-          },
-          "data": "0x{{ data ../../build/release/child-script-example }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": {{ def_type auth }}
-          },
-          "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000004",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": {{ def_type secp256k1_data }}
-          },
-          "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
-        }
-      ],
-      "header_deps": []
-    },
-    "tx": {
-      "version": "0x0",
-      "cell_deps": [
-      ],
-      "header_deps": [],
-      "inputs": [
-      ],
-      "outputs": [
-        {
-          "capacity": "0x0",
+  "mock_info": {
+    "inputs": [
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
             "code_hash": "0x{{ ref_type child-script-example }}",
             "hash_type": "type"
-          }
+          },
+          "type": null
+        },
+        "data": "0x"
+      }
+    ],
+    "cell_deps": [
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type child-script-example }}"
+        },
+        "data": "0x{{ data ../../build/release/child-script-example }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type auth }}"
+        },
+        "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type secp256k1_data }}"
+        },
+        "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
+      }
+    ]
+  },
+  "tx": {
+    "outputs": [
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type child-script-example }}",
+          "hash_type": "type"
         }
-      ],
-      "witnesses": [
-        "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
-      ],
-      "outputs_data": [
-        "0x"
-      ]
-    }
+      }
+    ],
+    "witnesses": [
+      "0x55000000100000005500000055000000410000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+    ],
+    "outputs_data": [
+      "0x"
+    ]
   }
-  
+}

--- a/ckb-debugger-tests/templates/cl-always-success-info-cell.json
+++ b/ckb-debugger-tests/templates/cl-always-success-info-cell.json
@@ -2,13 +2,6 @@
   "mock_info": {
     "inputs": [
       {
-        "input": {
-          "previous_output": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "index": "0x0"
-          },
-          "since": "0x0"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -23,13 +16,6 @@
     ],
     "cell_deps": [
       {
-        "cell_dep": {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -42,13 +28,6 @@
         "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/ckb-combine-lock }}"
       },
       {
-        "cell_dep": {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -61,13 +40,6 @@
         "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-always-success }}"
       },
       {
-        "cell_dep": {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000004",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -79,14 +51,9 @@
         },
         "data": "0x"
       }
-    ],
-    "header_deps": []
+    ]
   },
   "tx": {
-    "version": "0x0",
-    "cell_deps": [ ],
-    "header_deps": [],
-    "inputs": [],
     "outputs": [
       {
         "capacity": "0x0",

--- a/ckb-debugger-tests/templates/cl-always-success.json
+++ b/ckb-debugger-tests/templates/cl-always-success.json
@@ -2,13 +2,6 @@
   "mock_info": {
     "inputs": [
       {
-        "input": {
-          "previous_output": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
-            "index": "0x0"
-          },
-          "since": "0x0"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -23,13 +16,6 @@
     ],
     "cell_deps": [
       {
-        "cell_dep": {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -42,13 +28,6 @@
         "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/ckb-combine-lock }}"
       },
       {
-        "cell_dep": {
-          "out_point": {
-            "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-            "index": "0x0"
-          },
-          "dep_type": "code"
-        },
         "output": {
           "capacity": "0x10000000",
           "lock": {
@@ -60,14 +39,9 @@
         },
         "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-always-success }}"
       }
-    ],
-    "header_deps": []
+    ]
   },
   "tx": {
-    "version": "0x0",
-    "cell_deps": [],
-    "header_deps": [],
-    "inputs": [ ],
     "outputs": [
       {
         "capacity": "0x0",

--- a/ckb-debugger-tests/templates/cl-child-script.json
+++ b/ckb-debugger-tests/templates/cl-child-script.json
@@ -1,126 +1,84 @@
 {
-    "mock_info": {
-      "inputs": [
-        {
-          "input": {
-            "previous_output": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000002",
-              "index": "0x0"
-            },
-            "since": "0x0"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-              "code_hash": "0x{{ ref_type combine_lock }}",
-              "hash_type": "type"
-            },
-            "type": null
-          },
-          "data": "0x"
-        }
-      ],
-      "cell_deps": [
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000005",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",
-            "lock": {
-              "args": "0x",
-              "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-              "hash_type": "data1"
-            },
-            "type": "{{ def_type combine_lock }}"
-          },
-          "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/ckb-combine-lock }}"
-        },  
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000001",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type child-script-example }}"
-          },
-          "data": "0x{{ data ../../build/release/child-script-example }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000003",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type auth }}"
-          },
-          "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
-        },
-        {
-          "cell_dep": {
-            "out_point": {
-              "tx_hash": "0x0000000000000000000000000000000000000000000000000000000000000004",
-              "index": "0x0"
-            },
-            "dep_type": "code"
-          },
-          "output": {
-            "capacity": "0x10000000",            
-            "lock": {
-                "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-                "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
-                "hash_type": "data1"
-            },
-            "type": "{{ def_type secp256k1_data }}"
-          },
-          "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
-        }
-      ],
-      "header_deps": []
-    },
-    "tx": {
-      "version": "0x0",
-      "cell_deps": [],
-      "header_deps": [],
-      "inputs": [],
-      "outputs": [
-        {
-          "capacity": "0x0",
+  "mock_info": {
+    "inputs": [
+      {
+        "output": {
+          "capacity": "0x10000000",
           "lock": {
             "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
-            "code_hash": "0x{{ ref_type child-script-example }}",
+            "code_hash": "0x{{ ref_type combine_lock }}",
             "hash_type": "type"
-          }
+          },
+          "type": null
+        },
+        "data": "0x"
+      }
+    ],
+    "cell_deps": [
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type combine_lock }}"
+        },
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/ckb-combine-lock }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type child-script-example }}"
+        },
+        "data": "0x{{ data ../../build/release/child-script-example }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type auth }}"
+        },
+        "data": "0x{{ data ../../tests/test-child-script-example/src/bin/auth }}"
+      },
+      {
+        "output": {
+          "capacity": "0x10000000",
+          "lock": {
+            "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+            "code_hash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+            "hash_type": "data1"
+          },
+          "type": "{{ def_type secp256k1_data }}"
+        },
+        "data": "0x{{ data ../../tests/test-child-script-example/src/bin/secp256k1_data }}"
+      }
+    ]
+  },
+  "tx": {
+    "outputs": [
+      {
+        "capacity": "0x0",
+        "lock": {
+          "args": "0x00AE9DF3447C404A645BC48BEA4B7643B95AC5C3AE",
+          "code_hash": "0x{{ ref_type child-script-example }}",
+          "hash_type": "type"
         }
-      ],
-      "witnesses": [
-      ],
-      "outputs_data": [
-        "0x"
-      ]
-    }
+      }
+    ],
+    "witnesses": [],
+    "outputs_data": [
+      "0x"
+    ]
   }
-  
+}


### PR DESCRIPTION
Some fields in tx.json are trivial or duplicated for testing purposes, including:
1. mock_info.cell_deps[0].cell_dep
2. mock_info.inputs[0].input
3. tx.version
4. tx.cell_deps
5. tx.header_deps
6. tx.inputs
7. mock_info.header_deps

These fields can now be auto-populated, but it is still possible to manually specify them if desired.