### PR TITLE
Set lto to true

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ overflow-checks = true
 opt-level = 3
 panic = 'abort'
 strip = true
+lto = true
 
 [profile.dev]
 strip = true

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dev:
 	capsule build --release -- --features log
 
 install:
-	cargo install --rev 6bb45f3 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
+	cargo install --locked --rev 6bb45f3 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 	mv ~/.cargo/bin/ckb-debugger ~/.cargo/bin/ckb-debugger-2023
 	wget 'https://github.com/nervosnetwork/capsule/releases/download/v0.9.0/capsule_v0.9.0_x86_64-linux.tar.gz'
 	tar xzvf capsule_v0.9.0_x86_64-linux.tar.gz

--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ dev:
 	capsule build --release -- --features log
 
 install:
-	cargo install --locked --rev 6bb45f3 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
+	cargo install --locked --rev 02f4656 --git https://github.com/nervosnetwork/ckb-standalone-debugger ckb-debugger
 	mv ~/.cargo/bin/ckb-debugger ~/.cargo/bin/ckb-debugger-2023
 	wget 'https://github.com/nervosnetwork/capsule/releases/download/v0.9.0/capsule_v0.9.0_x86_64-linux.tar.gz'
 	tar xzvf capsule_v0.9.0_x86_64-linux.tar.gz


### PR DESCRIPTION
It reduces binary `combine_lock` from 84k to 62k.
The following setting might not reduce binary size: codegen-units = 1
