### PR TITLE
Global registry initializing values

### DIFF
--- a/contracts/global-registry/src/error.rs
+++ b/contracts/global-registry/src/error.rs
@@ -19,6 +19,7 @@ pub enum Error {
     UpdateFailed,
     LockScriptNotExisting,
     LockScriptDup,
+    InvalidInitValues,
 }
 
 impl From<SysError> for Error {


### PR DESCRIPTION
When global registry is initializing, we need to set a hash pair (current hash, next hash) to contain all possible hashes.
