### PR TITLE
Add support for moleculec-c2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,6 +184,7 @@ dependencies = [
  "ckb-std",
  "hex",
  "log 0.4.17",
+ "molecule2",
 ]
 
 [[package]]
@@ -228,6 +229,7 @@ dependencies = [
  "hex",
  "log 0.4.17",
  "molecule",
+ "molecule2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -998,6 +998,7 @@ dependencies = [
 [[package]]
 name = "molecule2"
 version = "0.1.1"
+source = "git+https://github.com/XuJiandong/moleculec-c2.git?rev=4c97e75#4c97e75cb608ba208bda98ce85ea429dabe91424"
 
 [[package]]
 name = "numext-constructor"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "hex",
  "log 0.4.17",
  "molecule",
+ "molecule2",
 ]
 
 [[package]]
@@ -993,6 +994,10 @@ dependencies = [
  "cfg-if",
  "faster-hex 0.6.1",
 ]
+
+[[package]]
+name = "molecule2"
+version = "0.1.1"
 
 [[package]]
 name = "numext-constructor"

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ ci:
 
 # this is optional
 install-moleculec:
-	cargo install --git https://github.com/XuJiandong/moleculec-c2.git --rev 717f288 moleculec-c2
+	cargo install --git https://github.com/XuJiandong/moleculec-c2.git --rev 4f1bd3c moleculec-c2
 	cargo install --force --version "0.7.3" "moleculec"
 
 install:

--- a/Makefile
+++ b/Makefile
@@ -5,17 +5,25 @@ MOLC := moleculec
 all:
 	capsule build --release
 
-mol:
-	${MOLC} --language rust --schema-file crates/molecule-types/combine_lock.mol | rustfmt > crates/molecule-types/src/combine_lock.rs
-	${MOLC} --language rust --schema-file crates/molecule-types/lock_wrapper.mol | rustfmt > crates/molecule-types/src/lock_wrapper.rs
+mol: ckb-lock-common/src/generated/blockchain.rs
+	${MOLC} --language rust --schema-file crates/types/combine_lock.mol | rustfmt > crates/types/src/combine_lock.rs
+	${MOLC} --language rust --schema-file crates/types/lock_wrapper.mol | rustfmt > crates/types/src/lock_wrapper.rs
+
+target/blockchain.json: crates/types/blockchain.mol
+	${MOLC} --language - --schema-file $^ --format json > $@
+
+ckb-lock-common/src/generated/blockchain.rs: target/blockchain.json
+	moleculec-c2 --rust --input $< | rustfmt > $@
 
 ci:
 	cd tests/global-registry && cargo test && cd ../..
 	capsule build --release
 	make -C ckb-debugger-tests all
 
-dev:
-	capsule build --release -- --features log
+# this is optional
+install-moleculec:
+	cargo install --git https://github.com/XuJiandong/moleculec-c2.git --rev cece491 moleculec-c2
+	cargo install --force --version "0.7.3" "moleculec"
 
 install:
 	wget 'https://github.com/XuJiandong/ckb-standalone-debugger/releases/download/ckb2023-0621/ckb-debugger-linux-x64.tar.gz'
@@ -25,4 +33,3 @@ install:
 	wget 'https://github.com/nervosnetwork/capsule/releases/download/v0.10.0/capsule_v0.10.0_x86_64-linux.tar.gz'
 	tar xzvf capsule_v0.10.0_x86_64-linux.tar.gz
 	mv capsule_v0.10.0_x86_64-linux/capsule ~/.cargo/bin
-	cargo install moleculec --git https://github.com/nervosnetwork/molecule.git --rev 1306c29c529ab375e0368ffeb691bd8c7bbf0403

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,9 @@ all:
 mol: ckb-lock-common/src/generated/blockchain.rs
 	${MOLC} --language rust --schema-file crates/types/combine_lock.mol | rustfmt > crates/types/src/combine_lock.rs
 	${MOLC} --language rust --schema-file crates/types/lock_wrapper.mol | rustfmt > crates/types/src/lock_wrapper.rs
-
-target/blockchain.json: crates/types/blockchain.mol
-	${MOLC} --language - --schema-file $^ --format json > $@
-
-ckb-lock-common/src/generated/blockchain.rs: target/blockchain.json
-	moleculec-c2 --rust --input $< | rustfmt > $@
+	${MOLC} --language - --schema-file crates/types/blockchain.mol --format json | moleculec-c2 --rust --input - | rustfmt > ckb-lock-common/src/generated/blockchain.rs
+	${MOLC} --language - --schema-file crates/types/lock_wrapper.mol --format json | moleculec-c2 --rust --input - | rustfmt > ckb-lock-common/src/generated/lock_wrapper.rs
+	${MOLC} --language - --schema-file crates/types/combine_lock.mol --format json | moleculec-c2 --rust --input - | rustfmt > ckb-lock-common/src/generated/combine_lock.rs
 
 ci:
 	cd tests/global-registry && cargo test && cd ../..
@@ -22,7 +19,7 @@ ci:
 
 # this is optional
 install-moleculec:
-	cargo install --git https://github.com/XuJiandong/moleculec-c2.git --rev cece491 moleculec-c2
+	cargo install --git https://github.com/XuJiandong/moleculec-c2.git --rev 717f288 moleculec-c2
 	cargo install --force --version "0.7.3" "moleculec"
 
 install:

--- a/ckb-debugger-tests/Makefile
+++ b/ckb-debugger-tests/Makefile
@@ -1,6 +1,6 @@
 
 CKB_DEBUGGER ?= ckb-debugger-2023
-BUILD ?= release
+BUILD ?=
 
 ## cl: combine lock
 ## gr: combine lock with global registry
@@ -32,92 +32,92 @@ all: \
 	gr-update \
 
 cl-always-success:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 cl-always-success-3i3c:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=0
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=2
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=0
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=2
 
 cl-cl-always-success:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 cl-child-script:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 gr-child-script:
-	cargo run --$(BUILD) --bin gr-child-script -- --has-config-cell |  ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-child-script -- --has-config-cell |  ${CKB_DEBUGGER} --tx-file=- -s lock
 
 gr-child-script-no-config-cell:
-	cargo run --$(BUILD) --bin gr-child-script | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-child-script | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 gr-init:
-	cargo run --$(BUILD) --bin gr-init | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type output
+	cargo run $(BUILD) --bin gr-init | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type output
 
 gr-insert:
-	cargo run --$(BUILD) --bin gr-insert | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=1 --cell-type input
-	cargo run --$(BUILD) --bin gr-insert | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
-	cargo run --$(BUILD) --bin gr-insert | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-insert | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=1 --cell-type input
+	cargo run $(BUILD) --bin gr-insert | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
+	cargo run $(BUILD) --bin gr-insert | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 gr-general-insert:
-	cargo run --$(BUILD) --bin gr-general -- --insert | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
-	cargo run --$(BUILD) --bin gr-general -- --insert | ${CKB_DEBUGGER} --tx-file=- -s lock
-	cargo run --$(BUILD) --bin gr-general -- --insert | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
+	cargo run $(BUILD) --bin gr-general -- --insert | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
+	cargo run $(BUILD) --bin gr-general -- --insert | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-general -- --insert | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
 
 gr-general-batch-insert:
-	cargo run --$(BUILD) --bin gr-general -- --batch-insert | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
-	cargo run --$(BUILD) --bin gr-general -- --batch-insert | ${CKB_DEBUGGER} --tx-file=- -s lock
-	cargo run --$(BUILD) --bin gr-general -- --batch-insert | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
+	cargo run $(BUILD) --bin gr-general -- --batch-insert | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
+	cargo run $(BUILD) --bin gr-general -- --batch-insert | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-general -- --batch-insert | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
 
 gr-general-batch-transforming:
-	cargo run --$(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
-	cargo run --$(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s lock
-	cargo run --$(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
-	cargo run --$(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=2
+	cargo run $(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
+	cargo run $(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=1
+	cargo run $(BUILD) --bin gr-general -- --batch-transforming | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=2
 
 gr-general-update:
-	cargo run --$(BUILD) --bin gr-general -- --update | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=0
-	cargo run --$(BUILD) --bin gr-general -- --update | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
+	cargo run $(BUILD) --bin gr-general -- --update | ${CKB_DEBUGGER} --tx-file=- -s lock --cell-index=0
+	cargo run $(BUILD) --bin gr-general -- --update | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
 
 gr-general-insert-fail-modify:
-	cargo run --$(BUILD) --bin gr-general -- --insert-fail-modify | \
+	cargo run $(BUILD) --bin gr-general -- --insert-fail-modify | \
 	${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input | grep "Run result: 54"
 
 gr-general-insert-fail-gap:
-	cargo run --$(BUILD) --bin gr-general -- --insert-fail-gap | \
+	cargo run $(BUILD) --bin gr-general -- --insert-fail-gap | \
 	${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input | grep "Run result: 53"
 
 gr-update:
-	cargo run --$(BUILD) --bin gr-update | ${CKB_DEBUGGER} --tx-file=- -s lock
-	cargo run --$(BUILD) --bin gr-update | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
-	cargo run --$(BUILD) --bin gr-update | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type output
+	cargo run $(BUILD) --bin gr-update | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin gr-update | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type input
+	cargo run $(BUILD) --bin gr-update | ${CKB_DEBUGGER} --tx-file=- -s type --cell-index=0 --cell-type output
 
 child-script-success:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 child-script-long-witness:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 child-script-multi-inputs:
-	cargo run --$(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
+	cargo run $(BUILD) --bin $@ | ${CKB_DEBUGGER} --tx-file=- -s lock
 
 negative-cl-always-failure:
-	cargo run --$(BUILD) --bin negative -- cl-always-failure | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 84"
+	cargo run $(BUILD) --bin negative -- cl-always-failure | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 84"
 
 negative-cl-child-script-config-hash-error:
-	cargo run --$(BUILD) --bin negative -- cl-child-script-config-hash-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 86"
+	cargo run $(BUILD) --bin negative -- cl-child-script-config-hash-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 86"
 
 negative-cl-child-script-sig-error:
-	cargo run --$(BUILD) --bin negative -- cl-child-script-sig-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 84"
+	cargo run $(BUILD) --bin negative -- cl-child-script-sig-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 84"
 
 negative-cl-cl-always-failure:
-	cargo run --$(BUILD) --bin negative -- cl-cl-always-failure | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 84"
+	cargo run $(BUILD) --bin negative -- cl-cl-always-failure | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 84"
 
 negative-cl-index-error:
-	cargo run --$(BUILD) --bin negative -- cl-index-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 83"
+	cargo run $(BUILD) --bin negative -- cl-index-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 83"
 
 negative-cl-vec-index-error:
-	cargo run --$(BUILD) --bin negative -- cl-vec-index-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 82"
+	cargo run $(BUILD) --bin negative -- cl-vec-index-error | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 82"
 
 negative-cl-witness-length-wrong:
-	cargo run --$(BUILD) --bin negative -- cl-witness-length-wrong | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 85"
+	cargo run $(BUILD) --bin negative -- cl-witness-length-wrong | ${CKB_DEBUGGER} --tx-file=- -s lock | grep "Run result: 85"

--- a/ckb-debugger-tests/src/bin/auth-script-exec-success.rs
+++ b/ckb-debugger-tests/src/bin/auth-script-exec-success.rs
@@ -38,6 +38,12 @@ pub fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let mut tx = read_tx_template("../ckb-debugger-tests/templates/auth-script-success.json")?;
     update_auth_code_hash(&mut tx);
+    tx.tx.witnesses.push(JsonBytes::from_bytes(
+        WitnessArgsBuilder::default()
+            .lock(Some(Bytes::from(vec![0; 65])).pack())
+            .build()
+            .as_bytes(),
+    ));
 
     let message = generate_sighash_all(&tx, 0)?;
 

--- a/ckb-lock-common/Cargo.toml
+++ b/ckb-lock-common/Cargo.toml
@@ -15,3 +15,5 @@ ckb-combine-lock-types = { path = "../crates/types" }
 ckb-std = { version = "0.14.0", features = ["ckb2023"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 log = { version = "0.4.17", default-features = false }
+# molecule2 = { git = "https://github.com/XuJiandong/moleculec-c2.git", rev = "cece491" }
+molecule2 = { path = "../../moleculec-c2/molecule2" }

--- a/ckb-lock-common/Cargo.toml
+++ b/ckb-lock-common/Cargo.toml
@@ -15,5 +15,4 @@ ckb-combine-lock-types = { path = "../crates/types" }
 ckb-std = { version = "0.14.0", features = ["ckb2023"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 log = { version = "0.4.17", default-features = false }
-# molecule2 = { git = "https://github.com/XuJiandong/moleculec-c2.git", rev = "cece491" }
-molecule2 = { path = "../../moleculec-c2/molecule2" }
+molecule2 = { git = "https://github.com/XuJiandong/moleculec-c2.git", rev = "4c97e75" }

--- a/ckb-lock-common/src/generate_sighash_all.rs
+++ b/ckb-lock-common/src/generate_sighash_all.rs
@@ -9,7 +9,7 @@ use ckb_std::syscalls::{load_input_by_field, load_witness, SysError};
 
 const CHUNK_SIZE: usize = 32768;
 
-pub fn generate_sighash_all() -> Result<[u8; 32], Error> {
+pub fn generate_sighash_all(index: usize) -> Result<[u8; 32], Error> {
     // Digest first witness in the script group.
     let chunks = ChunksLoader::new(load_witness, CHUNK_SIZE, 0, Source::GroupInput).into_iter();
     let mut ctx = new_blake2b();
@@ -17,16 +17,35 @@ pub fn generate_sighash_all() -> Result<[u8; 32], Error> {
     ctx.update(&tx_hash);
     let total_len = get_witness_len(0, Source::GroupInput)?;
     ctx.update(&(total_len as u64).to_le_bytes());
-    let location = get_signature_location(0, Source::GroupInput)?;
+    let location = get_signature_location(index, 0, Source::GroupInput)?;
     let mut current_offset = 0;
     for (_, mut chunk_data) in chunks {
         let chunk_len = chunk_data.len();
-        if location.0 >= current_offset && location.0 < (current_offset + chunk_len) {
+        if location.0 >= current_offset {
+            if location.0 < (current_offset + chunk_len) {
+                let end = location.0 + location.1;
+                if end >= (current_offset + chunk_len) {
+                    // case 1:
+                    // chunk_begin, signature_begin, chunk_end, signature_end
+                    chunk_data[location.0..].fill(0);
+                } else {
+                    // case 2:
+                    // chunk_begin, signature_begin, signature_end, chunk_end
+                    chunk_data[location.0..(end - current_offset)].fill(0);
+                }
+            }
+        } else {
             let end = location.0 + location.1;
-            if end >= (current_offset + chunk_len) {
-                chunk_data[location.0..].fill(0);
-            } else {
-                chunk_data[location.0..(end - current_offset)].fill(0);
+            if end > current_offset {
+                if end >= (current_offset + chunk_len) {
+                    // case 3:
+                    // signature_begin, chunk_begin, chunk_end, signature_end
+                    chunk_data[..].fill(0);
+                } else {
+                    // case 4:
+                    // signature_begin, chunk_begin, signature_end, chunk_end
+                    chunk_data[..(end - current_offset)].fill(0);
+                }
             }
         }
         ctx.update(&chunk_data);

--- a/ckb-lock-common/src/generate_sighash_all.rs
+++ b/ckb-lock-common/src/generate_sighash_all.rs
@@ -19,14 +19,12 @@ pub fn generate_sighash_all(target: &SimpleCursor) -> Result<[u8; 32], Error> {
     let total_len = get_witness_len(0, Source::GroupInput)?;
     ctx.update(&(total_len as u64).to_le_bytes());
     let mut chunk_offset = 0;
+    let target = target.offset as usize..target.offset as usize + target.size as usize;
     for (_, mut chunk) in chunks {
-        if let Some((begin, end)) = get_intersection(
-            chunk_offset,
-            chunk.len(),
-            target.offset as usize,
-            target.size as usize,
-        ) {
-            chunk[begin..end].fill(0);
+        if let Some(slice) =
+            get_intersection(chunk_offset..chunk_offset + chunk.len(), target.clone())
+        {
+            chunk[slice].fill(0);
         }
         ctx.update(&chunk);
         chunk_offset += chunk.len();

--- a/ckb-lock-common/src/generate_sighash_all.rs
+++ b/ckb-lock-common/src/generate_sighash_all.rs
@@ -1,5 +1,6 @@
 use crate::blake2b::new_blake2b;
 use crate::error::Error;
+use crate::intersection::get_intersection;
 use crate::simple_cursor::{get_witness_len, SimpleCursor};
 use alloc::{vec, vec::Vec};
 use blake2b_rs::Blake2b;
@@ -9,7 +10,7 @@ use ckb_std::syscalls::{load_input_by_field, load_witness, SysError};
 
 const CHUNK_SIZE: usize = 32768;
 
-pub fn generate_sighash_all(cursor: &SimpleCursor) -> Result<[u8; 32], Error> {
+pub fn generate_sighash_all(target: &SimpleCursor) -> Result<[u8; 32], Error> {
     // Digest first witness in the script group.
     let chunks = ChunksLoader::new(load_witness, CHUNK_SIZE, 0, Source::GroupInput).into_iter();
     let mut ctx = new_blake2b();
@@ -17,40 +18,18 @@ pub fn generate_sighash_all(cursor: &SimpleCursor) -> Result<[u8; 32], Error> {
     ctx.update(&tx_hash);
     let total_len = get_witness_len(0, Source::GroupInput)?;
     ctx.update(&(total_len as u64).to_le_bytes());
-    let mut current_offset = 0;
-    let cursor_offset = cursor.offset as usize;
-    let cursor_size = cursor.size as usize;
-    for (_, mut chunk_data) in chunks {
-        let chunk_len = chunk_data.len();
-        if cursor_offset >= current_offset {
-            if cursor_offset < (current_offset + chunk_len) {
-                let end = cursor_offset + cursor_size;
-                if end >= (current_offset + chunk_len) {
-                    // case 1:
-                    // chunk_begin, signature_begin, chunk_end, signature_end
-                    chunk_data[cursor_offset..].fill(0);
-                } else {
-                    // case 2:
-                    // chunk_begin, signature_begin, signature_end, chunk_end
-                    chunk_data[cursor_offset..(end - current_offset)].fill(0);
-                }
-            }
-        } else {
-            let end = cursor_offset + cursor_size;
-            if end > current_offset {
-                if end >= (current_offset + chunk_len) {
-                    // case 3:
-                    // signature_begin, chunk_begin, chunk_end, signature_end
-                    chunk_data[..].fill(0);
-                } else {
-                    // case 4:
-                    // signature_begin, chunk_begin, signature_end, chunk_end
-                    chunk_data[..(end - current_offset)].fill(0);
-                }
-            }
+    let mut chunk_offset = 0;
+    for (_, mut chunk) in chunks {
+        if let Some((begin, end)) = get_intersection(
+            chunk_offset,
+            chunk.len(),
+            target.offset as usize,
+            target.size as usize,
+        ) {
+            chunk[begin..end].fill(0);
         }
-        ctx.update(&chunk_data);
-        current_offset += chunk_len;
+        ctx.update(&chunk);
+        chunk_offset += chunk.len();
     }
     // Digest other witnesses in the script group.
     load_and_hash_witness(&mut ctx, 1, Source::GroupInput);

--- a/ckb-lock-common/src/generate_sighash_all.rs
+++ b/ckb-lock-common/src/generate_sighash_all.rs
@@ -1,6 +1,6 @@
 use crate::blake2b::new_blake2b;
 use crate::error::Error;
-use crate::utils::{get_signature_location, get_witness_len};
+use crate::simple_cursor::{get_witness_len, SimpleCursor};
 use alloc::{vec, vec::Vec};
 use blake2b_rs::Blake2b;
 use ckb_std::ckb_constants::{InputField, Source};
@@ -9,7 +9,7 @@ use ckb_std::syscalls::{load_input_by_field, load_witness, SysError};
 
 const CHUNK_SIZE: usize = 32768;
 
-pub fn generate_sighash_all(index: usize) -> Result<[u8; 32], Error> {
+pub fn generate_sighash_all(cursor: &SimpleCursor) -> Result<[u8; 32], Error> {
     // Digest first witness in the script group.
     let chunks = ChunksLoader::new(load_witness, CHUNK_SIZE, 0, Source::GroupInput).into_iter();
     let mut ctx = new_blake2b();
@@ -17,25 +17,26 @@ pub fn generate_sighash_all(index: usize) -> Result<[u8; 32], Error> {
     ctx.update(&tx_hash);
     let total_len = get_witness_len(0, Source::GroupInput)?;
     ctx.update(&(total_len as u64).to_le_bytes());
-    let location = get_signature_location(index, 0, Source::GroupInput)?;
     let mut current_offset = 0;
+    let cursor_offset = cursor.offset as usize;
+    let cursor_size = cursor.size as usize;
     for (_, mut chunk_data) in chunks {
         let chunk_len = chunk_data.len();
-        if location.0 >= current_offset {
-            if location.0 < (current_offset + chunk_len) {
-                let end = location.0 + location.1;
+        if cursor_offset >= current_offset {
+            if cursor_offset < (current_offset + chunk_len) {
+                let end = cursor_offset + cursor_size;
                 if end >= (current_offset + chunk_len) {
                     // case 1:
                     // chunk_begin, signature_begin, chunk_end, signature_end
-                    chunk_data[location.0..].fill(0);
+                    chunk_data[cursor_offset..].fill(0);
                 } else {
                     // case 2:
                     // chunk_begin, signature_begin, signature_end, chunk_end
-                    chunk_data[location.0..(end - current_offset)].fill(0);
+                    chunk_data[cursor_offset..(end - current_offset)].fill(0);
                 }
             }
         } else {
-            let end = location.0 + location.1;
+            let end = cursor_offset + cursor_size;
             if end > current_offset {
                 if end >= (current_offset + chunk_len) {
                     // case 3:

--- a/ckb-lock-common/src/generate_sighash_all.rs
+++ b/ckb-lock-common/src/generate_sighash_all.rs
@@ -24,7 +24,7 @@ pub fn generate_sighash_all(target: &SimpleCursor) -> Result<[u8; 32], Error> {
         if let Some(slice) =
             get_intersection(chunk_offset..chunk_offset + chunk.len(), target.clone())
         {
-            chunk[slice].fill(0);
+            chunk[slice.start - chunk_offset..slice.end - chunk_offset].fill(0);
         }
         ctx.update(&chunk);
         chunk_offset += chunk.len();

--- a/ckb-lock-common/src/generated/blockchain.rs
+++ b/ckb-lock-common/src/generated/blockchain.rs
@@ -837,6 +837,7 @@ impl WitnessArgs {
         if cur.option_is_none() {
             None
         } else {
+            let cur = cur.convert_to_rawbytes().unwrap();
             Some(cur.into())
         }
     }
@@ -848,6 +849,7 @@ impl WitnessArgs {
         if cur.option_is_none() {
             None
         } else {
+            let cur = cur.convert_to_rawbytes().unwrap();
             Some(cur.into())
         }
     }
@@ -859,6 +861,7 @@ impl WitnessArgs {
         if cur.option_is_none() {
             None
         } else {
+            let cur = cur.convert_to_rawbytes().unwrap();
             Some(cur.into())
         }
     }

--- a/ckb-lock-common/src/generated/blockchain.rs
+++ b/ckb-lock-common/src/generated/blockchain.rs
@@ -1,0 +1,864 @@
+#![allow(dead_code)]
+#![allow(unused_imports)]
+extern crate alloc;
+use alloc::vec::Vec;
+use molecule2::Cursor;
+
+pub struct Uint32 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Uint32 {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Uint32 {
+    pub fn len(&self) -> usize {
+        4
+    }
+}
+
+impl Uint32 {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Uint64 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Uint64 {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Uint64 {
+    pub fn len(&self) -> usize {
+        8
+    }
+}
+
+impl Uint64 {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Uint128 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Uint128 {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Uint128 {
+    pub fn len(&self) -> usize {
+        16
+    }
+}
+
+impl Uint128 {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Byte32 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Byte32 {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Byte32 {
+    pub fn len(&self) -> usize {
+        32
+    }
+}
+
+impl Byte32 {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Uint256 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Uint256 {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Uint256 {
+    pub fn len(&self) -> usize {
+        32
+    }
+}
+
+impl Uint256 {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Bytes {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Bytes {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Bytes {
+    pub fn len(&self) -> usize {
+        self.cursor.fixvec_length()
+    }
+}
+
+impl Bytes {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.fixvec_slice_by_index(1, index).unwrap();
+        cur.into()
+    }
+}
+// warning: BytesOpt not implemented for Rust
+pub struct BytesOpt {
+    pub cursor: Cursor,
+}
+impl From<Cursor> for BytesOpt {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+pub struct BytesVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for BytesVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl BytesVec {
+    pub fn len(&self) -> usize {
+        self.cursor.dynvec_length()
+    }
+}
+
+impl BytesVec {
+    pub fn get(&self, index: usize) -> Cursor {
+        let cur = self.cursor.dynvec_slice_by_index(index).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+
+pub struct Byte32Vec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Byte32Vec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Byte32Vec {
+    pub fn len(&self) -> usize {
+        self.cursor.fixvec_length()
+    }
+}
+
+impl Byte32Vec {
+    pub fn get(&self, index: usize) -> Cursor {
+        let cur = self.cursor.fixvec_slice_by_index(32, index).unwrap();
+        cur.into()
+    }
+}
+// warning: ScriptOpt not implemented for Rust
+pub struct ScriptOpt {
+    pub cursor: Cursor,
+}
+impl From<Cursor> for ScriptOpt {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+pub struct ProposalShortId {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ProposalShortId {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl ProposalShortId {
+    pub fn len(&self) -> usize {
+        10
+    }
+}
+
+impl ProposalShortId {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct UncleBlockVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for UncleBlockVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl UncleBlockVec {
+    pub fn len(&self) -> usize {
+        self.cursor.dynvec_length()
+    }
+}
+
+impl UncleBlockVec {
+    pub fn get(&self, index: usize) -> UncleBlock {
+        let cur = self.cursor.dynvec_slice_by_index(index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct TransactionVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for TransactionVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl TransactionVec {
+    pub fn len(&self) -> usize {
+        self.cursor.dynvec_length()
+    }
+}
+
+impl TransactionVec {
+    pub fn get(&self, index: usize) -> Transaction {
+        let cur = self.cursor.dynvec_slice_by_index(index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct ProposalShortIdVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ProposalShortIdVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl ProposalShortIdVec {
+    pub fn len(&self) -> usize {
+        self.cursor.fixvec_length()
+    }
+}
+
+impl ProposalShortIdVec {
+    pub fn get(&self, index: usize) -> Cursor {
+        let cur = self.cursor.fixvec_slice_by_index(10, index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct CellDepVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellDepVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl CellDepVec {
+    pub fn len(&self) -> usize {
+        self.cursor.fixvec_length()
+    }
+}
+
+impl CellDepVec {
+    pub fn get(&self, index: usize) -> CellDep {
+        let cur = self.cursor.fixvec_slice_by_index(37, index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct CellInputVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellInputVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl CellInputVec {
+    pub fn len(&self) -> usize {
+        self.cursor.fixvec_length()
+    }
+}
+
+impl CellInputVec {
+    pub fn get(&self, index: usize) -> CellInput {
+        let cur = self.cursor.fixvec_slice_by_index(44, index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct CellOutputVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellOutputVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl CellOutputVec {
+    pub fn len(&self) -> usize {
+        self.cursor.dynvec_length()
+    }
+}
+
+impl CellOutputVec {
+    pub fn get(&self, index: usize) -> CellOutput {
+        let cur = self.cursor.dynvec_slice_by_index(index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Script {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Script {
+    fn from(cursor: Cursor) -> Self {
+        Script { cursor }
+    }
+}
+
+impl Script {
+    pub fn code_hash(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl Script {
+    pub fn hash_type(&self) -> u8 {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl Script {
+    pub fn args(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+
+pub struct OutPoint {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for OutPoint {
+    fn from(cursor: Cursor) -> Self {
+        OutPoint { cursor }
+    }
+}
+
+impl OutPoint {
+    pub fn tx_hash(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(0, 32).unwrap();
+        cur.into()
+    }
+}
+
+impl OutPoint {
+    pub fn index(&self) -> u32 {
+        let cur = self.cursor.slice_by_offset(32, 4).unwrap();
+        cur.into()
+    }
+}
+
+pub struct CellInput {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellInput {
+    fn from(cursor: Cursor) -> Self {
+        CellInput { cursor }
+    }
+}
+
+impl CellInput {
+    pub fn since(&self) -> u64 {
+        let cur = self.cursor.slice_by_offset(0, 8).unwrap();
+        cur.into()
+    }
+}
+
+impl CellInput {
+    pub fn previous_output(&self) -> OutPoint {
+        let cur = self.cursor.slice_by_offset(8, 36).unwrap();
+        cur.into()
+    }
+}
+
+pub struct CellOutput {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellOutput {
+    fn from(cursor: Cursor) -> Self {
+        CellOutput { cursor }
+    }
+}
+
+impl CellOutput {
+    pub fn capacity(&self) -> u64 {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl CellOutput {
+    pub fn lock(&self) -> Script {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl CellOutput {
+    pub fn type_(&self) -> Option<Script> {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        if cur.option_is_none() {
+            None
+        } else {
+            Some(cur.into())
+        }
+    }
+}
+
+pub struct CellDep {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellDep {
+    fn from(cursor: Cursor) -> Self {
+        CellDep { cursor }
+    }
+}
+
+impl CellDep {
+    pub fn out_point(&self) -> OutPoint {
+        let cur = self.cursor.slice_by_offset(0, 36).unwrap();
+        cur.into()
+    }
+}
+
+impl CellDep {
+    pub fn dep_type(&self) -> u8 {
+        let cur = self.cursor.slice_by_offset(36, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct RawTransaction {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for RawTransaction {
+    fn from(cursor: Cursor) -> Self {
+        RawTransaction { cursor }
+    }
+}
+
+impl RawTransaction {
+    pub fn version(&self) -> u32 {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl RawTransaction {
+    pub fn cell_deps(&self) -> CellDepVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl RawTransaction {
+    pub fn header_deps(&self) -> Byte32Vec {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        cur.into()
+    }
+}
+
+impl RawTransaction {
+    pub fn inputs(&self) -> CellInputVec {
+        let cur = self.cursor.table_slice_by_index(3).unwrap();
+        cur.into()
+    }
+}
+
+impl RawTransaction {
+    pub fn outputs(&self) -> CellOutputVec {
+        let cur = self.cursor.table_slice_by_index(4).unwrap();
+        cur.into()
+    }
+}
+
+impl RawTransaction {
+    pub fn outputs_data(&self) -> BytesVec {
+        let cur = self.cursor.table_slice_by_index(5).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Transaction {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Transaction {
+    fn from(cursor: Cursor) -> Self {
+        Transaction { cursor }
+    }
+}
+
+impl Transaction {
+    pub fn raw(&self) -> RawTransaction {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl Transaction {
+    pub fn witnesses(&self) -> BytesVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct RawHeader {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for RawHeader {
+    fn from(cursor: Cursor) -> Self {
+        RawHeader { cursor }
+    }
+}
+
+impl RawHeader {
+    pub fn version(&self) -> u32 {
+        let cur = self.cursor.slice_by_offset(0, 4).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn compact_target(&self) -> u32 {
+        let cur = self.cursor.slice_by_offset(4, 4).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn timestamp(&self) -> u64 {
+        let cur = self.cursor.slice_by_offset(8, 8).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn number(&self) -> u64 {
+        let cur = self.cursor.slice_by_offset(16, 8).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn epoch(&self) -> u64 {
+        let cur = self.cursor.slice_by_offset(24, 8).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn parent_hash(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(32, 32).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn transactions_root(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(64, 32).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn proposals_hash(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(96, 32).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn extra_hash(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(128, 32).unwrap();
+        cur.into()
+    }
+}
+
+impl RawHeader {
+    pub fn dao(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(160, 32).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Header {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Header {
+    fn from(cursor: Cursor) -> Self {
+        Header { cursor }
+    }
+}
+
+impl Header {
+    pub fn raw(&self) -> RawHeader {
+        let cur = self.cursor.slice_by_offset(0, 192).unwrap();
+        cur.into()
+    }
+}
+
+impl Header {
+    pub fn nonce(&self) -> Cursor {
+        let cur = self.cursor.slice_by_offset(192, 16).unwrap();
+        cur.into()
+    }
+}
+
+pub struct UncleBlock {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for UncleBlock {
+    fn from(cursor: Cursor) -> Self {
+        UncleBlock { cursor }
+    }
+}
+
+impl UncleBlock {
+    pub fn header(&self) -> Header {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl UncleBlock {
+    pub fn proposals(&self) -> ProposalShortIdVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct Block {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Block {
+    fn from(cursor: Cursor) -> Self {
+        Block { cursor }
+    }
+}
+
+impl Block {
+    pub fn header(&self) -> Header {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl Block {
+    pub fn uncles(&self) -> UncleBlockVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl Block {
+    pub fn transactions(&self) -> TransactionVec {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        cur.into()
+    }
+}
+
+impl Block {
+    pub fn proposals(&self) -> ProposalShortIdVec {
+        let cur = self.cursor.table_slice_by_index(3).unwrap();
+        cur.into()
+    }
+}
+
+pub struct BlockV1 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for BlockV1 {
+    fn from(cursor: Cursor) -> Self {
+        BlockV1 { cursor }
+    }
+}
+
+impl BlockV1 {
+    pub fn header(&self) -> Header {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl BlockV1 {
+    pub fn uncles(&self) -> UncleBlockVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl BlockV1 {
+    pub fn transactions(&self) -> TransactionVec {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        cur.into()
+    }
+}
+
+impl BlockV1 {
+    pub fn proposals(&self) -> ProposalShortIdVec {
+        let cur = self.cursor.table_slice_by_index(3).unwrap();
+        cur.into()
+    }
+}
+
+impl BlockV1 {
+    pub fn extension(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(4).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+
+pub struct CellbaseWitness {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CellbaseWitness {
+    fn from(cursor: Cursor) -> Self {
+        CellbaseWitness { cursor }
+    }
+}
+
+impl CellbaseWitness {
+    pub fn lock(&self) -> Script {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl CellbaseWitness {
+    pub fn message(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+
+pub struct WitnessArgs {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for WitnessArgs {
+    fn from(cursor: Cursor) -> Self {
+        WitnessArgs { cursor }
+    }
+}
+
+impl WitnessArgs {
+    pub fn lock(&self) -> Option<Cursor> {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        if cur.option_is_none() {
+            None
+        } else {
+            Some(cur.into())
+        }
+    }
+}
+
+impl WitnessArgs {
+    pub fn input_type(&self) -> Option<Cursor> {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        if cur.option_is_none() {
+            None
+        } else {
+            Some(cur.into())
+        }
+    }
+}
+
+impl WitnessArgs {
+    pub fn output_type(&self) -> Option<Cursor> {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        if cur.option_is_none() {
+            None
+        } else {
+            Some(cur.into())
+        }
+    }
+}

--- a/ckb-lock-common/src/generated/blockchain.rs
+++ b/ckb-lock-common/src/generated/blockchain.rs
@@ -2,6 +2,7 @@
 #![allow(unused_imports)]
 extern crate alloc;
 use alloc::vec::Vec;
+use core::convert::TryInto;
 use molecule2::Cursor;
 
 pub struct Uint32 {

--- a/ckb-lock-common/src/generated/combine_lock.rs
+++ b/ckb-lock-common/src/generated/combine_lock.rs
@@ -1,4 +1,3 @@
-
 #![allow(dead_code)]
 #![allow(unused_imports)]
 extern crate alloc;

--- a/ckb-lock-common/src/generated/combine_lock.rs
+++ b/ckb-lock-common/src/generated/combine_lock.rs
@@ -1,0 +1,201 @@
+
+#![allow(dead_code)]
+#![allow(unused_imports)]
+extern crate alloc;
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use molecule2::Cursor;
+
+use super::blockchain::*;
+pub struct ChildScript {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ChildScript {
+    fn from(cursor: Cursor) -> Self {
+        ChildScript { cursor }
+    }
+}
+
+impl ChildScript {
+    pub fn code_hash(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl ChildScript {
+    pub fn hash_type(&self) -> u8 {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl ChildScript {
+    pub fn args(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+
+pub struct ChildScriptVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ChildScriptVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl ChildScriptVec {
+    pub fn len(&self) -> usize {
+        self.cursor.fixvec_length()
+    }
+}
+
+impl ChildScriptVec {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.fixvec_slice_by_index(1, index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct ChildScriptVecVec {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ChildScriptVecVec {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl ChildScriptVecVec {
+    pub fn len(&self) -> usize {
+        self.cursor.dynvec_length()
+    }
+}
+
+impl ChildScriptVecVec {
+    pub fn get(&self, index: usize) -> Cursor {
+        let cur = self.cursor.dynvec_slice_by_index(index).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+
+pub struct ChildScriptArray {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ChildScriptArray {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl ChildScriptArray {
+    pub fn len(&self) -> usize {
+        self.cursor.dynvec_length()
+    }
+}
+
+impl ChildScriptArray {
+    pub fn get(&self, index: usize) -> ChildScript {
+        let cur = self.cursor.dynvec_slice_by_index(index).unwrap();
+        cur.into()
+    }
+}
+
+pub struct ChildScriptConfig {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ChildScriptConfig {
+    fn from(cursor: Cursor) -> Self {
+        ChildScriptConfig { cursor }
+    }
+}
+
+impl ChildScriptConfig {
+    pub fn array(&self) -> ChildScriptArray {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl ChildScriptConfig {
+    pub fn index(&self) -> ChildScriptVecVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+// warning: ChildScriptConfigOpt not implemented for Rust
+pub struct ChildScriptConfigOpt {
+    pub cursor: Cursor,
+}
+impl From<Cursor> for ChildScriptConfigOpt {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+pub struct Uint16 {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for Uint16 {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+impl Uint16 {
+    pub fn len(&self) -> usize {
+        2
+    }
+}
+
+impl Uint16 {
+    pub fn get(&self, index: usize) -> u8 {
+        let cur = self.cursor.slice_by_offset(1 * index, 1).unwrap();
+        cur.into()
+    }
+}
+
+pub struct CombineLockWitness {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for CombineLockWitness {
+    fn from(cursor: Cursor) -> Self {
+        CombineLockWitness { cursor }
+    }
+}
+
+impl CombineLockWitness {
+    pub fn index(&self) -> u16 {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl CombineLockWitness {
+    pub fn inner_witness(&self) -> BytesVec {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        cur.into()
+    }
+}
+
+impl CombineLockWitness {
+    pub fn script_config(&self) -> Option<ChildScriptConfig> {
+        let cur = self.cursor.table_slice_by_index(2).unwrap();
+        if cur.option_is_none() {
+            None
+        } else {
+            Some(cur.into())
+        }
+    }
+}

--- a/ckb-lock-common/src/generated/lock_wrapper.rs
+++ b/ckb-lock-common/src/generated/lock_wrapper.rs
@@ -1,4 +1,3 @@
-
 #![allow(dead_code)]
 #![allow(unused_imports)]
 extern crate alloc;

--- a/ckb-lock-common/src/generated/lock_wrapper.rs
+++ b/ckb-lock-common/src/generated/lock_wrapper.rs
@@ -1,0 +1,71 @@
+
+#![allow(dead_code)]
+#![allow(unused_imports)]
+extern crate alloc;
+use alloc::vec::Vec;
+use core::convert::TryInto;
+use molecule2::Cursor;
+
+use super::blockchain::*;
+pub struct ConfigCellData {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for ConfigCellData {
+    fn from(cursor: Cursor) -> Self {
+        ConfigCellData { cursor }
+    }
+}
+
+impl ConfigCellData {
+    pub fn wrapped_script(&self) -> Script {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        cur.into()
+    }
+}
+
+impl ConfigCellData {
+    pub fn script_config(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}
+// warning: ConfigCellDataOpt not implemented for Rust
+pub struct ConfigCellDataOpt {
+    pub cursor: Cursor,
+}
+impl From<Cursor> for ConfigCellDataOpt {
+    fn from(cursor: Cursor) -> Self {
+        Self { cursor }
+    }
+}
+
+pub struct LockWrapperWitness {
+    pub cursor: Cursor,
+}
+
+impl From<Cursor> for LockWrapperWitness {
+    fn from(cursor: Cursor) -> Self {
+        LockWrapperWitness { cursor }
+    }
+}
+
+impl LockWrapperWitness {
+    pub fn wrapped_script(&self) -> Option<Script> {
+        let cur = self.cursor.table_slice_by_index(0).unwrap();
+        if cur.option_is_none() {
+            None
+        } else {
+            Some(cur.into())
+        }
+    }
+}
+
+impl LockWrapperWitness {
+    pub fn wrapped_witness(&self) -> Cursor {
+        let cur = self.cursor.table_slice_by_index(1).unwrap();
+        let cur2 = cur.convert_to_rawbytes().unwrap();
+        cur2
+    }
+}

--- a/ckb-lock-common/src/generated/mod.rs
+++ b/ckb-lock-common/src/generated/mod.rs
@@ -1,0 +1,1 @@
+pub mod blockchain;

--- a/ckb-lock-common/src/generated/mod.rs
+++ b/ckb-lock-common/src/generated/mod.rs
@@ -1,1 +1,3 @@
 pub mod blockchain;
+pub mod combine_lock;
+pub mod lock_wrapper;

--- a/ckb-lock-common/src/intersection.rs
+++ b/ckb-lock-common/src/intersection.rs
@@ -1,0 +1,38 @@
+// don't add extra code in the file.
+// it will be included in test cases in native code.
+
+pub fn get_intersection(
+    chunk_offset: usize,
+    chunk_size: usize,
+    target_offset: usize,
+    target_size: usize,
+) -> Option<(usize, usize)> {
+    if target_offset >= chunk_offset {
+        if target_offset < (chunk_offset + chunk_size) {
+            let end = target_offset + target_size;
+            if end >= (chunk_offset + chunk_size) {
+                // case 1:
+                // chunk_begin, signature_begin, chunk_end, signature_end
+                return Some((target_offset - chunk_offset, chunk_size));
+            } else {
+                // case 2:
+                // chunk_begin, signature_begin, signature_end, chunk_end
+                return Some((target_offset - chunk_offset, end - chunk_offset));
+            }
+        }
+    } else {
+        let end = target_offset + target_size;
+        if end > chunk_offset {
+            if end >= (chunk_offset + chunk_size) {
+                // case 3:
+                // signature_begin, chunk_begin, chunk_end, signature_end
+                return Some((0, chunk_size));
+            } else {
+                // case 4:
+                // signature_begin, chunk_begin, signature_end, chunk_end
+                return Some((0, end - chunk_offset));
+            }
+        }
+    }
+    None
+}

--- a/ckb-lock-common/src/intersection.rs
+++ b/ckb-lock-common/src/intersection.rs
@@ -3,35 +3,30 @@
 use core::ops::Range;
 
 pub fn get_intersection(chunk: Range<usize>, target: Range<usize>) -> Option<Range<usize>> {
-    let chunk_offset = chunk.start;
     let chunk_size = chunk.end - chunk.start;
-    let target_offset = target.start;
-    let target_size = target.end - target.start;
 
-    if target_offset >= chunk_offset {
-        if target_offset < (chunk_offset + chunk_size) {
-            let end = target_offset + target_size;
-            if end >= (chunk_offset + chunk_size) {
+    if target.start >= chunk.start {
+        if target.start < (chunk.start + chunk_size) {
+            if target.end >= (chunk.start + chunk_size) {
                 // case 1:
                 // chunk_begin, signature_begin, chunk_end, signature_end
-                return Some(target_offset - chunk_offset..chunk_size);
+                return Some(target.start - chunk.start..chunk_size);
             } else {
                 // case 2:
                 // chunk_begin, signature_begin, signature_end, chunk_end
-                return Some(target_offset - chunk_offset..end - chunk_offset);
+                return Some(target.start - chunk.start..target.end - chunk.start);
             }
         }
     } else {
-        let end = target_offset + target_size;
-        if end > chunk_offset {
-            if end >= (chunk_offset + chunk_size) {
+        if target.end > chunk.start {
+            if target.end >= chunk.end {
                 // case 3:
                 // signature_begin, chunk_begin, chunk_end, signature_end
                 return Some(0..chunk_size);
             } else {
                 // case 4:
                 // signature_begin, chunk_begin, signature_end, chunk_end
-                return Some(0..end - chunk_offset);
+                return Some(0..target.end - chunk.start);
             }
         }
     }

--- a/ckb-lock-common/src/intersection.rs
+++ b/ckb-lock-common/src/intersection.rs
@@ -1,23 +1,24 @@
 // don't add extra code in the file.
 // it will be included in test cases in native code.
+use core::ops::Range;
 
-pub fn get_intersection(
-    chunk_offset: usize,
-    chunk_size: usize,
-    target_offset: usize,
-    target_size: usize,
-) -> Option<(usize, usize)> {
+pub fn get_intersection(chunk: Range<usize>, target: Range<usize>) -> Option<Range<usize>> {
+    let chunk_offset = chunk.start;
+    let chunk_size = chunk.end - chunk.start;
+    let target_offset = target.start;
+    let target_size = target.end - target.start;
+
     if target_offset >= chunk_offset {
         if target_offset < (chunk_offset + chunk_size) {
             let end = target_offset + target_size;
             if end >= (chunk_offset + chunk_size) {
                 // case 1:
                 // chunk_begin, signature_begin, chunk_end, signature_end
-                return Some((target_offset - chunk_offset, chunk_size));
+                return Some(target_offset - chunk_offset..chunk_size);
             } else {
                 // case 2:
                 // chunk_begin, signature_begin, signature_end, chunk_end
-                return Some((target_offset - chunk_offset, end - chunk_offset));
+                return Some(target_offset - chunk_offset..end - chunk_offset);
             }
         }
     } else {
@@ -26,11 +27,11 @@ pub fn get_intersection(
             if end >= (chunk_offset + chunk_size) {
                 // case 3:
                 // signature_begin, chunk_begin, chunk_end, signature_end
-                return Some((0, chunk_size));
+                return Some(0..chunk_size);
             } else {
                 // case 4:
                 // signature_begin, chunk_begin, signature_end, chunk_end
-                return Some((0, end - chunk_offset));
+                return Some(0..end - chunk_offset);
             }
         }
     }

--- a/ckb-lock-common/src/intersection.rs
+++ b/ckb-lock-common/src/intersection.rs
@@ -3,32 +3,12 @@
 use core::ops::Range;
 
 pub fn get_intersection(chunk: Range<usize>, target: Range<usize>) -> Option<Range<usize>> {
-    let chunk_size = chunk.end - chunk.start;
+    let max_start = chunk.start.max(target.start);
+    let min_end = chunk.end.min(target.end);
 
-    if target.start >= chunk.start {
-        if target.start < (chunk.start + chunk_size) {
-            if target.end >= (chunk.start + chunk_size) {
-                // case 1:
-                // chunk_begin, signature_begin, chunk_end, signature_end
-                return Some(target.start - chunk.start..chunk_size);
-            } else {
-                // case 2:
-                // chunk_begin, signature_begin, signature_end, chunk_end
-                return Some(target.start - chunk.start..target.end - chunk.start);
-            }
-        }
+    if max_start < min_end {
+        Some(max_start..min_end)
     } else {
-        if target.end > chunk.start {
-            if target.end >= chunk.end {
-                // case 3:
-                // signature_begin, chunk_begin, chunk_end, signature_end
-                return Some(0..chunk_size);
-            } else {
-                // case 4:
-                // signature_begin, chunk_begin, signature_end, chunk_end
-                return Some(0..target.end - chunk.start);
-            }
-        }
+        None
     }
-    None
 }

--- a/ckb-lock-common/src/lib.rs
+++ b/ckb-lock-common/src/lib.rs
@@ -6,6 +6,7 @@ pub mod ckb_auth;
 pub mod error;
 pub mod generate_sighash_all;
 pub mod generated;
+pub mod intersection;
 pub mod lock_wrapper;
 pub mod logger;
 pub mod simple_cursor;

--- a/ckb-lock-common/src/lib.rs
+++ b/ckb-lock-common/src/lib.rs
@@ -5,6 +5,7 @@ pub mod blake2b;
 pub mod ckb_auth;
 pub mod error;
 pub mod generate_sighash_all;
+pub mod generated;
 pub mod lock_wrapper;
 pub mod logger;
 pub mod transforming;

--- a/ckb-lock-common/src/lib.rs
+++ b/ckb-lock-common/src/lib.rs
@@ -8,5 +8,6 @@ pub mod generate_sighash_all;
 pub mod generated;
 pub mod lock_wrapper;
 pub mod logger;
+pub mod simple_cursor;
 pub mod transforming;
 pub mod utils;

--- a/ckb-lock-common/src/simple_cursor.rs
+++ b/ckb-lock-common/src/simple_cursor.rs
@@ -1,0 +1,84 @@
+use core::fmt::Display;
+
+use crate::error::Error;
+use alloc::{boxed::Box, vec::Vec};
+use ckb_std::{
+    ckb_constants::Source,
+    syscalls::{load_witness, SysError},
+};
+use molecule2::{Cursor, Read};
+
+pub struct SimpleCursor {
+    pub offset: u32,
+    pub size: u32,
+}
+
+impl SimpleCursor {
+    pub fn new(offset: u32, size: u32) -> Self {
+        Self { offset, size }
+    }
+    pub fn new_from_cursor(cursor: &Cursor) -> Self {
+        Self {
+            offset: cursor.offset as u32,
+            size: cursor.size as u32,
+        }
+    }
+
+    pub fn parse(str: &str) -> Result<Self, Error> {
+        let result: Vec<u32> = str
+            .split_terminator(":")
+            .into_iter()
+            .map(|n| u32::from_str_radix(n, 16).unwrap())
+            .collect::<Vec<_>>();
+        if result.len() != 2 {
+            return Err(Error::WrongHex);
+        }
+        Ok(SimpleCursor {
+            offset: result[0],
+            size: result[1],
+        })
+    }
+}
+
+impl Display for SimpleCursor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "{:x}:{:x}", self.offset, self.size)
+    }
+}
+
+pub struct WitnessDataSource {
+    source: Source,
+    index: usize,
+}
+
+impl WitnessDataSource {
+    pub fn new(source: Source, index: usize) -> Self {
+        WitnessDataSource { source, index }
+    }
+    pub fn as_cursor(self) -> Result<Cursor, Error> {
+        let len = get_witness_len(self.index, self.source)?;
+        Ok(Cursor::new(len, Box::new(self)))
+    }
+}
+
+impl Read for WitnessDataSource {
+    fn read(&self, buf: &mut [u8], offset: usize) -> Result<usize, molecule2::Error> {
+        match load_witness(buf, offset, self.index, self.source) {
+            Ok(size) => Ok(size),
+            Err(SysError::LengthNotEnough(_)) => Ok(buf.len()),
+            Err(_) => Err(molecule2::Error::Read),
+        }
+    }
+}
+
+pub fn get_witness_len(index: usize, source: Source) -> Result<usize, Error> {
+    let mut buf = [0u8; 4];
+    let len = match load_witness(&mut buf, 0, index, source) {
+        Ok(size) => size,
+        Err(SysError::LengthNotEnough(size)) => size,
+        Err(_) => {
+            return Err(Error::IndexOutOfBound);
+        }
+    };
+    Ok(len)
+}

--- a/ckb-lock-common/src/simple_cursor.rs
+++ b/ckb-lock-common/src/simple_cursor.rs
@@ -72,7 +72,7 @@ impl Read for WitnessDataSource {
 }
 
 pub fn get_witness_len(index: usize, source: Source) -> Result<usize, Error> {
-    let mut buf = [0u8; 4];
+    let mut buf = [0u8; 0];
     let len = match load_witness(&mut buf, 0, index, source) {
         Ok(size) => size,
         Err(SysError::LengthNotEnough(size)) => size,

--- a/ckb-lock-common/src/transforming.rs
+++ b/ckb-lock-common/src/transforming.rs
@@ -1,3 +1,6 @@
+// don't add extra code in the file.
+// it will be included in test cases in native code.
+
 use super::error::Error;
 use alloc::vec::Vec;
 

--- a/ckb-lock-common/src/utils.rs
+++ b/ckb-lock-common/src/utils.rs
@@ -137,6 +137,6 @@ pub fn get_signature_location(source: Source, index: usize) -> Result<(usize, us
     let cursor = data_source.as_cursor()?;
     let witness_args: WitnessArgs = cursor.into();
     let lock = witness_args.lock().unwrap();
-    let bytes = lock.convert_to_rawbytes().map_err(|e| Error::Encoding)?;
+    let bytes = lock.convert_to_rawbytes().map_err(|_| Error::Encoding)?;
     Ok((bytes.offset, bytes.size))
 }

--- a/contracts/child-script-example/Cargo.toml
+++ b/contracts/child-script-example/Cargo.toml
@@ -13,3 +13,4 @@ ckb-std = { version = "0.14.0", features = ["ckb2023"] }
 ckb-lock-common = { path = "../../ckb-lock-common" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
+molecule2 = { git = "https://github.com/XuJiandong/moleculec-c2.git", rev = "4c97e75" }

--- a/contracts/child-script-example/src/entry.rs
+++ b/contracts/child-script-example/src/entry.rs
@@ -44,7 +44,6 @@ fn parse_witness() -> Result<Cursor, Error> {
     if len == 0 {
         let witness_args: WitnessArgs = cursor.into();
         let lock = witness_args.lock().unwrap();
-        let lock = lock.convert_to_rawbytes().unwrap();
         return Ok(lock);
     }
     if len == 2 {

--- a/contracts/child-script-example/src/entry.rs
+++ b/contracts/child-script-example/src/entry.rs
@@ -5,13 +5,17 @@ use ckb_lock_common::ckb_auth::{
     ckb_auth, AuthAlgorithmIdType, CkbAuthType, CkbEntryType, EntryCategoryType,
 };
 use ckb_lock_common::generate_sighash_all::generate_sighash_all;
+use ckb_lock_common::generated::blockchain::WitnessArgs;
+use ckb_lock_common::simple_cursor::{SimpleCursor, WitnessDataSource};
+use ckb_std::env;
 use ckb_std::{
     ckb_constants::Source,
     ckb_types::{bytes::Bytes, core::ScriptHashType, prelude::*},
-    high_level::{load_script, load_witness_args},
+    high_level::load_script,
 };
 use core::result::Result;
 use log::info;
+use molecule2::Cursor;
 
 static DL_CODE_HASH: [u8; 32] = [
     0xD4, 0x0C, 0xCE, 0x7F, 0xDF, 0xF8, 0x24, 0xF6, 0x31, 0x7B, 0x31, 0x09, 0x94, 0xF5, 0x88, 0x73,
@@ -19,7 +23,7 @@ static DL_CODE_HASH: [u8; 32] = [
 ];
 static DL_HASH_TYPE: ScriptHashType = ScriptHashType::Data1;
 
-fn parse_execution_args() -> Result<Bytes, Error> {
+fn parse_args() -> Result<Bytes, Error> {
     let len = ckb_std::env::argv().len();
     if len == 0 {
         let script = load_script()?;
@@ -33,62 +37,46 @@ fn parse_execution_args() -> Result<Bytes, Error> {
     return Err(Error::WrongFormat);
 }
 
-fn parse_execution_witness_args_lock() -> Result<Bytes, Error> {
-    let len = ckb_std::env::argv().len();
+fn parse_witness() -> Result<Cursor, Error> {
+    let len = env::argv().len();
+    let data_source = WitnessDataSource::new(Source::GroupInput, 0);
+    let mut cursor = data_source.as_cursor().unwrap();
     if len == 0 {
-        let execution_witness_args = load_witness_args(0, Source::GroupInput)?;
-        let execution_witness_args_lock: Bytes =
-            execution_witness_args.lock().to_opt().unwrap().unpack();
-        return Ok(execution_witness_args_lock);
+        let witness_args: WitnessArgs = cursor.into();
+        let lock = witness_args.lock().unwrap();
+        let lock = lock.convert_to_rawbytes().unwrap();
+        return Ok(lock);
     }
-    if len == 3 {
-        return Ok(Bytes::from(hex::decode(
-            ckb_std::env::argv()[1].to_bytes(),
-        )?));
-    }
-    return Err(Error::WrongFormat);
-}
+    if len == 2 || len == 3 {
+        let arg = env::argv()[1].to_str().unwrap();
+        let simple_cursor = SimpleCursor::parse(arg).unwrap();
 
-fn parse_execution_index() -> Result<Vec<usize>, Error> {
-    let len = ckb_std::env::argv().len();
-    if len == 3 {
-        let s = ckb_std::env::argv()[2].to_string_lossy().into_owned();
-        if s.len() > 256 {
-            return Err(Error::WrongFormat);
-        }
-        let result: Vec<usize> = s
-            .split_terminator(":")
-            .into_iter()
-            .map(|n| {
-                let s = usize::from_str_radix(n, 16).unwrap();
-                if s > 1024 {
-                    panic!("too long index");
-                }
-                s
-            })
-            .collect::<Vec<_>>();
-        return Ok(result);
+        cursor.offset = simple_cursor.offset as usize;
+        cursor.size = simple_cursor.size as usize;
+        return Ok(cursor);
     }
     return Err(Error::WrongFormat);
 }
 
 pub fn main() -> Result<(), Error> {
     info!("child-script-example entry");
-    let execution_args = parse_execution_args()?;
+    let execution_args = parse_args()?;
     info!("child-script-example execution_args = {:?}", execution_args);
     let execution_args_slice = execution_args.as_ref();
-    let execution_witness_args_lock = parse_execution_witness_args_lock()?;
+    let cursor = parse_witness()?;
+    let simple_cursor = SimpleCursor::new_from_cursor(&cursor);
+    let witness_args_lock: Vec<u8> = cursor.try_into().unwrap();
     info!(
-        "child-script-example execution_witness_args_lock = {:?}",
-        execution_witness_args_lock
+        "child-script-example witness_args_lock (len = {})= {:?}",
+        witness_args_lock.len(),
+        &witness_args_lock
     );
     if execution_args_slice.len() != 21 {
         return Err(Error::WrongFormat);
     }
     let auth_id = execution_args_slice[0] as u8;
     let pubkey_hash: [u8; 20] = execution_args_slice[1..].try_into().unwrap();
-    let indexes = parse_execution_index()?;
-    let message = generate_sighash_all(indexes[0]).map_err(|_| Error::GeneratedMsgError)?;
+    let message = generate_sighash_all(&simple_cursor).map_err(|_| Error::GeneratedMsgError)?;
     let id = CkbAuthType {
         algorithm_id: AuthAlgorithmIdType::try_from(auth_id)?,
         pubkey_hash: pubkey_hash,
@@ -98,6 +86,6 @@ pub fn main() -> Result<(), Error> {
         hash_type: DL_HASH_TYPE,
         entry_category: EntryCategoryType::DynamicLinking,
     };
-    ckb_auth(&entry, &id, execution_witness_args_lock.as_ref(), &message)?;
+    ckb_auth(&entry, &id, witness_args_lock.as_ref(), &message)?;
     Ok(())
 }

--- a/contracts/ckb-combine-lock/Cargo.toml
+++ b/contracts/ckb-combine-lock/Cargo.toml
@@ -13,3 +13,4 @@ ckb-std = { version = "0.14.0", features = ["ckb2023"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 molecule = { version = "0.7.3", default-features = false }
+molecule2 = { git = "https://github.com/XuJiandong/moleculec-c2.git", rev = "4c97e75" }

--- a/contracts/ckb-combine-lock/src/entry.rs
+++ b/contracts/ckb-combine-lock/src/entry.rs
@@ -1,5 +1,6 @@
 use crate::error::Error;
 use alloc::ffi::CString;
+use alloc::format;
 use alloc::vec::Vec;
 use ckb_combine_lock_types::combine_lock::{
     ChildScriptConfig, ChildScriptConfigReader, CombineLockWitness, CombineLockWitnessReader,
@@ -115,6 +116,7 @@ pub fn main() -> Result<(), Error> {
             &[
                 CString::new(child_script_args.as_str()).unwrap().as_c_str(),
                 CString::new(child_script_inner_witness.as_str()).unwrap().as_c_str(),
+                CString::new(format!("{:x}", i)).unwrap().as_c_str(),
             ],
             8,
             &mut Vec::new(),

--- a/contracts/ckb-combine-lock/src/entry.rs
+++ b/contracts/ckb-combine-lock/src/entry.rs
@@ -40,7 +40,6 @@ fn parse_witness() -> Result<Cursor, Error> {
     if len == 0 {
         let witness_args: WitnessArgs = cursor.into();
         let lock = witness_args.lock().unwrap();
-        let lock = lock.convert_to_rawbytes().unwrap();
         return Ok(lock);
     }
     if len == 2 || len == 3 {
@@ -62,7 +61,6 @@ fn parse_script_config() -> Result<Bytes, Error> {
         let cursor = data_source.as_cursor().unwrap();
         let witness_args: WitnessArgs = cursor.into();
         let lock = witness_args.lock().unwrap();
-        let lock = lock.convert_to_rawbytes().unwrap();
         let combine_lock_witness: CombineLockWitness = lock.into();
         let script_config = combine_lock_witness.script_config().unwrap();
         let bytes: Vec<u8> = script_config.cursor.try_into().unwrap();

--- a/contracts/ckb-combine-lock/src/entry.rs
+++ b/contracts/ckb-combine-lock/src/entry.rs
@@ -2,20 +2,24 @@ use crate::error::Error;
 use alloc::ffi::CString;
 use alloc::format;
 use alloc::vec::Vec;
-use ckb_combine_lock_types::combine_lock::{
-    ChildScriptConfig, ChildScriptConfigReader, CombineLockWitness, CombineLockWitnessReader,
+use ckb_combine_lock_types::combine_lock::{ChildScriptConfig, ChildScriptConfigReader};
+use ckb_lock_common::{
+    blake2b::hash,
+    generated::{blockchain::WitnessArgs, combine_lock::CombineLockWitness},
+    simple_cursor::{SimpleCursor, WitnessDataSource},
+    utils::WRAPPED_SCRIPT_HASH_LEN,
 };
-use ckb_lock_common::{blake2b::hash, utils::WRAPPED_SCRIPT_HASH_LEN};
 
 use ckb_std::{
     ckb_constants::Source,
     ckb_types::{bytes::Bytes, core::ScriptHashType, prelude::*},
     env,
-    high_level::{load_script, load_witness_args, spawn_cell},
+    high_level::{load_script, spawn_cell},
 };
 use core::result::Result;
 use hex::{decode, encode};
 use log::{info, warn};
+use molecule2::Cursor;
 
 fn parse_args() -> Result<Bytes, Error> {
     let len = env::argv().len();
@@ -29,33 +33,52 @@ fn parse_args() -> Result<Bytes, Error> {
     return Err(Error::WrongFormat);
 }
 
-fn parse_witness() -> Result<Bytes, Error> {
+fn parse_witness() -> Result<Cursor, Error> {
     let len = env::argv().len();
+    let data_source = WitnessDataSource::new(Source::GroupInput, 0);
+    let mut cursor = data_source.as_cursor().unwrap();
     if len == 0 {
-        let witness = load_witness_args(0, Source::GroupInput)?;
-        let lock: Bytes = witness.lock().to_opt().unwrap().unpack();
+        let witness_args: WitnessArgs = cursor.into();
+        let lock = witness_args.lock().unwrap();
+        let lock = lock.convert_to_rawbytes().unwrap();
         return Ok(lock);
     }
     if len == 2 || len == 3 {
-        return Ok(Bytes::from(decode(env::argv()[1].to_bytes())?));
+        let arg = env::argv()[1].to_str().unwrap();
+        let simple_cursor = SimpleCursor::parse(arg).unwrap();
+
+        cursor.offset = simple_cursor.offset as usize;
+        cursor.size = simple_cursor.size as usize;
+        cursor.validate();
+        return Ok(cursor);
     }
     return Err(Error::WrongFormat);
 }
 
 fn parse_script_config() -> Result<Bytes, Error> {
     let len = ckb_std::env::argv().len();
+    let data_source = WitnessDataSource::new(Source::GroupInput, 0);
     if len == 0 {
-        let witness = load_witness_args(0, Source::GroupInput)?;
-        let witness: Bytes = witness.lock().to_opt().unwrap().unpack();
-        CombineLockWitnessReader::verify(&witness, false)?;
-        let combine_lock_witness = CombineLockWitness::new_unchecked(witness);
-        return Ok(combine_lock_witness.script_config().as_bytes());
+        let cursor = data_source.as_cursor().unwrap();
+        let witness_args: WitnessArgs = cursor.into();
+        let lock = witness_args.lock().unwrap();
+        let lock = lock.convert_to_rawbytes().unwrap();
+        let combine_lock_witness: CombineLockWitness = lock.into();
+        let script_config = combine_lock_witness.script_config().unwrap();
+        let bytes: Vec<u8> = script_config.cursor.try_into().unwrap();
+        return Ok(bytes.into());
     }
     if len == 2 {
-        let witness = Bytes::from(decode(env::argv()[1].to_bytes())?);
-        CombineLockWitnessReader::verify(&witness, false)?;
-        let combine_lock_witness = CombineLockWitness::new_unchecked(witness);
-        return Ok(combine_lock_witness.script_config().as_bytes());
+        let mut cursor = data_source.as_cursor().unwrap();
+        let arg = env::argv()[1].to_str().unwrap();
+        let simple_cursor = SimpleCursor::parse(arg).unwrap();
+        cursor.offset = simple_cursor.offset as usize;
+        cursor.size = simple_cursor.size as usize;
+        cursor.validate();
+        let combine_lock_witness: CombineLockWitness = cursor.into();
+        let script_config = combine_lock_witness.script_config().unwrap();
+        let bytes: Vec<u8> = script_config.cursor.try_into().unwrap();
+        return Ok(bytes.into());
     }
     if len == 3 {
         let script_config = Bytes::from(decode(env::argv()[2].to_bytes())?);
@@ -74,8 +97,9 @@ pub fn main() -> Result<(), Error> {
     // The `index` and `inner_witness` must be from local witness
     // The `script_config` can be from local witness or config cell.
     let witness_args_lock = parse_witness()?;
-    let witness = CombineLockWitness::from_slice(&witness_args_lock)?;
-    let witness_index = witness.index().unpack() as usize;
+
+    let witness: CombineLockWitness = witness_args_lock.into();
+    let witness_index = witness.index() as usize;
     let inner_witness = witness.inner_witness();
 
     let child_script_config = {
@@ -97,14 +121,22 @@ pub fn main() -> Result<(), Error> {
         let child_script = child_script_array.get(child_script_index).ok_or(Error::ChildScriptArrayIndexOutOfBounds)?;
         let child_script_args: Bytes = child_script.args().unpack();
         let child_script_args = encode(child_script_args.as_ref());
-        let child_script_inner_witness = inner_witness.get(i).ok_or(Error::InnerWitnessIndexOutOfBounds)?;
-        let child_script_inner_witness: Bytes = child_script_inner_witness.unpack();
-        let child_script_inner_witness = encode(child_script_inner_witness.as_ref());
+
+        if i >= inner_witness.len() {
+            return Err(Error::InnerWitnessIndexOutOfBounds);
+        }
+        let child_script_inner_witness = inner_witness.get(i);
+        let arg1 = SimpleCursor::new_from_cursor(&child_script_inner_witness);
+        let witness_cursor = format!("{}", arg1);
         info!(
-            "spawn code_hash={} hash_type={}",
+            "spawn code_hash = {}, hash_type = {}, index = {}, child_script_args = {:?}, witness = {}",
             child_script.code_hash(),
-            child_script.hash_type()
+            child_script.hash_type(),
+            i,
+            child_script_args,
+            witness_cursor
         );
+
         let spawn_ret = spawn_cell(
             child_script.code_hash().as_slice(),
             match u8::from(child_script.hash_type()) {
@@ -115,8 +147,7 @@ pub fn main() -> Result<(), Error> {
             },
             &[
                 CString::new(child_script_args.as_str()).unwrap().as_c_str(),
-                CString::new(child_script_inner_witness.as_str()).unwrap().as_c_str(),
-                CString::new(format!("{:x}", i)).unwrap().as_c_str(),
+                CString::new(witness_cursor).unwrap().as_c_str(),
             ],
             8,
             &mut Vec::new(),

--- a/contracts/lock-wrapper/src/entry.rs
+++ b/contracts/lock-wrapper/src/entry.rs
@@ -1,8 +1,11 @@
 extern crate alloc;
 use crate::error::Error;
-use ckb_combine_lock_types::lock_wrapper::{ConfigCellDataOptReader, LockWrapperWitnessReader};
+use alloc::{ffi::CString, format, vec::Vec};
+use ckb_combine_lock_types::lock_wrapper::ConfigCellDataOptReader;
 use ckb_lock_common::{
     blake2b::hash,
+    generated::{blockchain::WitnessArgs, lock_wrapper::LockWrapperWitness},
+    simple_cursor::{SimpleCursor, WitnessDataSource},
     transforming::{self, BatchTransformingStatus},
     utils::{
         config_cell_unchanged, get_current_hash, get_global_registry_id, get_next_hash,
@@ -14,7 +17,7 @@ use ckb_std::{
     ckb_types::{core::ScriptHashType, prelude::*},
     high_level::{
         encode_hex, exec_cell, load_cell_data, load_cell_lock, load_cell_type_hash, load_script,
-        load_witness_args, QueryIter,
+        QueryIter,
     },
     syscalls::exit,
 };
@@ -232,35 +235,34 @@ fn validate_config_cell(global_registry_id: &[u8; 32]) -> Result<(), Error> {
 /// execute wrapped script with no config cell
 ///
 fn exec_no_config(wrapped_script_hash: [u8; 32]) -> Result<(), Error> {
-    let witness = load_witness_args(0, Source::GroupInput)?;
-    let witness = witness.lock().to_opt().unwrap().raw_data();
+    let data_source = WitnessDataSource::new(Source::GroupInput, 0);
+    let cursor = data_source.as_cursor()?;
+    let witness_args: WitnessArgs = cursor.into();
+    let lock = witness_args.lock().unwrap();
+    let lock = lock.convert_to_rawbytes().unwrap();
+    let lock_wrapper: LockWrapperWitness = lock.into();
+    let wrapped_witness = lock_wrapper.wrapped_witness();
+    let wrapped_script = lock_wrapper.wrapped_script().unwrap();
 
-    LockWrapperWitnessReader::verify(&witness, false)?;
-    let lock_wrapper_witness = LockWrapperWitnessReader::new_unchecked(&witness);
-    let wrapped_script = lock_wrapper_witness.wrapped_script();
-    let wrapped_script = wrapped_script.to_opt().unwrap();
-    let wrapped_witness = lock_wrapper_witness.wrapped_witness();
-
-    if hash(wrapped_script.as_slice()) != wrapped_script_hash {
+    let wrapped_script_bytes: Vec<u8> = wrapped_script.cursor.clone().try_into().unwrap();
+    if hash(&wrapped_script_bytes) != wrapped_script_hash {
         return Err(Error::InvalidWrappedScriptHash);
     }
 
-    let hash_type = if wrapped_script.hash_type().as_slice() == &[1] {
+    let hash_type = if wrapped_script.hash_type() == 1 {
         ScriptHashType::Type
     } else {
         ScriptHashType::Data
     };
-
-    let arg0 = encode_hex(wrapped_script.args().raw_data());
-    let arg1 = encode_hex(wrapped_witness.raw_data());
+    let args_bytes: Vec<u8> = wrapped_script.args().try_into().unwrap();
+    let arg0 = encode_hex(&args_bytes);
+    let wrapped_witness_cursor = SimpleCursor::new_from_cursor(&wrapped_witness);
+    let arg1 = CString::new(format!("{}", wrapped_witness_cursor)).unwrap();
     debug!("arg0: {:?}", arg0);
     debug!("arg1: {:?}", arg1);
 
-    exec_cell(
-        wrapped_script.code_hash().as_slice(),
-        hash_type,
-        &[&arg0, &arg1],
-    )?;
+    let code_hash: Vec<u8> = wrapped_script.code_hash().try_into().unwrap();
+    exec_cell(&code_hash, hash_type, &[&arg0, &arg1])?;
     unreachable!();
 }
 
@@ -268,12 +270,13 @@ fn exec_no_config(wrapped_script_hash: [u8; 32]) -> Result<(), Error> {
 /// execute wrapped script with config cell
 ///
 fn exec_with_config(config_cell_data: &[u8]) -> Result<(), Error> {
-    let witness = load_witness_args(0, Source::GroupInput)?;
-    let witness = witness.lock().to_opt().unwrap().raw_data();
-
-    LockWrapperWitnessReader::verify(&witness, false)?;
-    let lock_wrapper_witness = LockWrapperWitnessReader::new_unchecked(&witness);
-    let wrapped_witness = lock_wrapper_witness.wrapped_witness();
+    let data_source = WitnessDataSource::new(Source::GroupInput, 0);
+    let cursor = data_source.as_cursor()?;
+    let witness_args: WitnessArgs = cursor.into();
+    let lock = witness_args.lock().unwrap();
+    let lock = lock.convert_to_rawbytes().unwrap();
+    let lock_wrapper: LockWrapperWitness = lock.into();
+    let wrapped_witness = lock_wrapper.wrapped_witness();
 
     ConfigCellDataOptReader::verify(config_cell_data, false)?;
     let config_cell_data = ConfigCellDataOptReader::new_unchecked(config_cell_data);
@@ -289,7 +292,8 @@ fn exec_with_config(config_cell_data: &[u8]) -> Result<(), Error> {
     };
 
     let arg0 = encode_hex(wrapped_script.args().raw_data());
-    let arg1 = encode_hex(wrapped_witness.raw_data());
+    let wrapped_witness_cursor = SimpleCursor::new_from_cursor(&wrapped_witness);
+    let arg1 = CString::new(format!("{}", wrapped_witness_cursor)).unwrap();
     let arg2 = encode_hex(script_config.raw_data());
 
     debug!("arg0: {:?}", arg0);

--- a/contracts/lock-wrapper/src/entry.rs
+++ b/contracts/lock-wrapper/src/entry.rs
@@ -239,7 +239,6 @@ fn exec_no_config(wrapped_script_hash: [u8; 32]) -> Result<(), Error> {
     let cursor = data_source.as_cursor()?;
     let witness_args: WitnessArgs = cursor.into();
     let lock = witness_args.lock().unwrap();
-    let lock = lock.convert_to_rawbytes().unwrap();
     let lock_wrapper: LockWrapperWitness = lock.into();
     let wrapped_witness = lock_wrapper.wrapped_witness();
     let wrapped_script = lock_wrapper.wrapped_script().unwrap();
@@ -274,7 +273,6 @@ fn exec_with_config(config_cell_data: &[u8]) -> Result<(), Error> {
     let cursor = data_source.as_cursor()?;
     let witness_args: WitnessArgs = cursor.into();
     let lock = witness_args.lock().unwrap();
-    let lock = lock.convert_to_rawbytes().unwrap();
     let lock_wrapper: LockWrapperWitness = lock.into();
     let wrapped_witness = lock_wrapper.wrapped_witness();
 

--- a/tests/global-registry/src/main.rs
+++ b/tests/global-registry/src/main.rs
@@ -10,6 +10,8 @@ mod transforming;
 
 use intersection::get_intersection;
 use transforming::{BatchTransformingStatus, Cell};
+use core::ops::Range;
+
 
 fn test(inputs: &[(u8, u8)], outputs: &[(u8, u8)], result: bool) {
     let mut batch = BatchTransformingStatus::new();
@@ -103,9 +105,11 @@ fn test_input_overlap() {
 fn test_intersection(
     chunk: (usize, usize),
     target: (usize, usize),
-    result: Option<(usize, usize)>,
+    result: Option<Range<usize>>,
 ) {
-    let r = get_intersection(chunk.0, chunk.1, target.0, target.1);
+    let chunk = chunk.0 .. (chunk.0 + chunk.1);
+    let target = target.0 .. (target.0 + target.1);
+    let r = get_intersection(chunk, target);
     assert_eq!(r, result);
 }
 
@@ -119,19 +123,19 @@ fn test_intersection_1() {
     test_intersection(chunk, target, None);
     let target = (0, 101);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 1)));
+    test_intersection(chunk, target, Some(0..1));
     let target = (0, 130);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 30)));
+    test_intersection(chunk, target, Some(0..30));
     let target = (0, 150);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 50)));
+    test_intersection(chunk, target, Some(0..50));
     let target = (0, 151);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 50)));
+    test_intersection(chunk, target, Some(0..50));
     let target = (0, 200);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 50)));
+    test_intersection(chunk, target, Some(0..50));
 
     let target = (99, 1);
     let chunk = (100, 50);
@@ -139,23 +143,23 @@ fn test_intersection_1() {
 
     let target = (100, 1);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 1)));
+    test_intersection(chunk, target, Some(0..1));
 
     let target = (100, 40);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 40)));
+    test_intersection(chunk, target, Some(0..40));
 
     let target = (100, 50);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((0, 50)));
+    test_intersection(chunk, target, Some(0..50));
 
     let target = (101, 50);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((1, 50)));
+    test_intersection(chunk, target, Some(1..50));
 
     let target = (149, 50);
     let chunk = (100, 50);
-    test_intersection(chunk, target, Some((49, 50)));
+    test_intersection(chunk, target, Some(49..50));
 
     let target = (150, 50);
     let chunk = (100, 50);

--- a/tests/global-registry/src/main.rs
+++ b/tests/global-registry/src/main.rs
@@ -3,9 +3,12 @@
 extern crate alloc;
 
 mod error;
+#[path = "../../../ckb-lock-common/src/intersection.rs"]
+mod intersection;
 #[path = "../../../ckb-lock-common/src/transforming.rs"]
 mod transforming;
 
+use intersection::get_intersection;
 use transforming::{BatchTransformingStatus, Cell};
 
 fn test(inputs: &[(u8, u8)], outputs: &[(u8, u8)], result: bool) {
@@ -95,6 +98,72 @@ fn test_input_overlap() {
     let input = Cell::new(0, [2; 32], [4; 32]);
     let result = batch.set_input(input);
     assert!(result.is_err());
+}
+
+fn test_intersection(
+    chunk: (usize, usize),
+    target: (usize, usize),
+    result: Option<(usize, usize)>,
+) {
+    let r = get_intersection(chunk.0, chunk.1, target.0, target.1);
+    assert_eq!(r, result);
+}
+
+#[test]
+fn test_intersection_1() {
+    let target = (0, 50);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, None);
+    let target = (0, 100);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, None);
+    let target = (0, 101);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 1)));
+    let target = (0, 130);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 30)));
+    let target = (0, 150);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 50)));
+    let target = (0, 151);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 50)));
+    let target = (0, 200);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 50)));
+
+    let target = (99, 1);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, None);
+
+    let target = (100, 1);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 1)));
+
+    let target = (100, 40);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 40)));
+
+    let target = (100, 50);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((0, 50)));
+
+    let target = (101, 50);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((1, 50)));
+
+    let target = (149, 50);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, Some((49, 50)));
+
+    let target = (150, 50);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, None);
+
+    let target = (200, 50);
+    let chunk = (100, 50);
+    test_intersection(chunk, target, None);
 }
 
 fn main() {}

--- a/tests/global-registry/src/main.rs
+++ b/tests/global-registry/src/main.rs
@@ -107,10 +107,13 @@ fn test_intersection(
     target: (usize, usize),
     result: Option<Range<usize>>,
 ) {
-    let chunk = chunk.0 .. (chunk.0 + chunk.1);
-    let target = target.0 .. (target.0 + target.1);
-    let r = get_intersection(chunk, target);
-    assert_eq!(r, result);
+    let r = get_intersection(chunk.0 .. (chunk.0 + chunk.1), target.0 .. (target.0 + target.1));
+    let r2 = if let Some(rr) = r {
+        Some(rr.start - chunk.0..rr.end - chunk.0)
+    } else {
+        r
+    };
+    assert_eq!(r2, result);
 }
 
 #[test]


### PR DESCRIPTION
Changes:
1. Add molecule2 
Now we can load molecule data structure on demand. It' not necessary to load all memory at once.
See https://github.com/XuJiandong/moleculec-c2 for more features.
2. Change `<witness>` argument into "<witness_offset>:<witness_size>"
