### PR TITLE
Use native toolchain without capsule/docker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,101 +3,16 @@
 version = 3
 
 [[package]]
-name = "adler"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
-
-[[package]]
-name = "aho-corasick"
-version = "0.6.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81ce3d38065e618af2d7b77e10c5ad9a069859b4be3c2250f674af3840d9c8a5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "aho-corasick"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43f6cb1bf222025340178f382c426f13757b2960e89779dfcb319c32542a5a41"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "anstream"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca84f3628370c59db74ee214b3263d58f9aadd9b4fe7e711fd87dc452b7f163"
-dependencies = [
- "anstyle",
- "anstyle-parse",
- "anstyle-query",
- "anstyle-wincon",
- "colorchoice",
- "is-terminal",
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a30da5c5f2d5e72842e00bcb57657162cdabef0931f40e2deb9b4140440cecd"
-
-[[package]]
-name = "anstyle-parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
-dependencies = [
- "utf8parse",
-]
-
-[[package]]
-name = "anstyle-query"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
-dependencies = [
- "windows-sys",
-]
-
-[[package]]
-name = "anstyle-wincon"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "180abfa45703aebe0093f79badacc01b8fd4ea2e35118747e5811127f926e188"
-dependencies = [
- "anstyle",
- "windows-sys",
-]
-
-[[package]]
 name = "anyhow"
 version = "1.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c7d0618f0e0b7e8ff11427422b64564d5fb0be1940354bfe2e0529b18a9d9b8"
 
 [[package]]
-name = "autocfg"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
-
-[[package]]
 name = "bit-vec"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "blake2b-ref"
@@ -110,6 +25,11 @@ name = "blake2b-ref"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "294d17c72e0ba59fad763caa112368d0672083779cdebbb97164f4bb4c1e339a"
+
+[[package]]
+name = "blake2b-ref"
+version = "0.3.1"
+source = "git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48#f1efc4872d67a8d4c4a57d2d0e16f8b5e53724b9"
 
 [[package]]
 name = "blake2b-rs"
@@ -126,18 +46,6 @@ name = "buddy-alloc"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c6aa666383df80e31d5e162998ed05880695bb377f2a98210978e586f006aaec"
-
-[[package]]
-name = "bumpalo"
-version = "3.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
-
-[[package]]
-name = "byteorder"
-version = "1.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14c189c53d098945499cdfa7ecc63567cf3886b3332b312a5b4585d8d3a6a610"
 
 [[package]]
 name = "bytes"
@@ -173,7 +81,7 @@ version = "0.1.0"
 dependencies = [
  "ckb-lock-common",
  "ckb-std",
- "log 0.4.17",
+ "log",
 ]
 
 [[package]]
@@ -183,30 +91,8 @@ dependencies = [
  "ckb-lock-common",
  "ckb-std",
  "hex",
- "log 0.4.17",
+ "log",
  "molecule2",
-]
-
-[[package]]
-name = "ckb-chain-spec"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76db6b5000404d17db8b533b073693e02a64989c5d99bea87e51ae51663577b7"
-dependencies = [
- "ckb-constant",
- "ckb-crypto",
- "ckb-dao-utils",
- "ckb-error",
- "ckb-hash",
- "ckb-jsonrpc-types",
- "ckb-pow",
- "ckb-rational",
- "ckb-resource",
- "ckb-traits",
- "ckb-types",
- "ckb-util",
- "serde",
- "toml",
 ]
 
 [[package]]
@@ -222,12 +108,12 @@ dependencies = [
 name = "ckb-combine-lock"
 version = "0.1.0"
 dependencies = [
- "blake2b-rs",
+ "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
  "ckb-combine-lock-types",
  "ckb-lock-common",
  "ckb-std",
  "hex",
- "log 0.4.17",
+ "log",
  "molecule",
  "molecule2",
 ]
@@ -239,80 +125,6 @@ dependencies = [
  "ckb-standalone-types",
  "ckb-types",
  "molecule",
-]
-
-[[package]]
-name = "ckb-constant"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20be5e1878b20d693945c0537fc813970aa61849bf89525c548afa1ad4a3e7d7"
-
-[[package]]
-name = "ckb-crypto"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb6ff995bead74fdba3d6993e8c320493a8a27de9735327be3d2e7275e362b7c"
-dependencies = [
- "ckb-fixed-hash",
- "faster-hex 0.6.1",
- "lazy_static",
- "rand",
- "secp256k1",
- "thiserror",
-]
-
-[[package]]
-name = "ckb-dao-utils"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11fdca090384bd478ea70034d769896ac5053768d31c914c241077221d7664ec"
-dependencies = [
- "byteorder",
- "ckb-error",
- "ckb-types",
-]
-
-[[package]]
-name = "ckb-debugger-api"
-version = "0.108.1"
-source = "git+https://github.com/nervosnetwork/ckb-standalone-debugger.git?rev=1a66c03#1a66c035de8db7092e578062d62729a93fe9c957"
-dependencies = [
- "ckb-chain-spec",
- "ckb-hash",
- "ckb-jsonrpc-types",
- "ckb-mock-tx-types",
- "ckb-script",
- "ckb-types",
- "ckb-vm",
- "faster-hex 0.4.1",
- "hex",
- "js-sys",
- "regex 1.8.4",
- "serde",
- "serde_json",
- "serde_plain",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "ckb-debugger-tests"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "ckb-combine-lock-types",
- "ckb-crypto",
- "ckb-debugger-api",
- "ckb-hash",
- "ckb-jsonrpc-types",
- "ckb-mock-tx-types",
- "ckb-types",
- "clap",
- "env_logger",
- "lazy_static",
- "log 0.4.17",
- "molecule",
- "serde_json",
- "serde_plain",
 ]
 
 [[package]]
@@ -343,7 +155,7 @@ version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "548c4f95e73c37b542969580c41635b830d9b79f2486d99944b3fd30c6e64b2f"
 dependencies = [
- "faster-hex 0.6.1",
+ "faster-hex",
  "serde",
  "thiserror",
 ]
@@ -371,26 +183,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-jsonrpc-types"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "069a36e5b50b1f7d83d77b472ab4dab5e942c0b2ea3f5671a7746a41455643d0"
-dependencies = [
- "ckb-types",
- "faster-hex 0.6.1",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "ckb-lock-common"
 version = "0.1.0"
 dependencies = [
- "blake2b-rs",
+ "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
  "ckb-combine-lock-types",
  "ckb-std",
  "hex",
- "log 0.4.17",
+ "log",
  "molecule",
  "molecule2",
 ]
@@ -402,17 +202,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56ccb671c5921be8a84686e6212ca184cb1d7c51cadcdbfcbd1cc3f042f5dfb8"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "ckb-mock-tx-types"
-version = "0.108.1"
-source = "git+https://github.com/nervosnetwork/ckb-standalone-debugger.git?rev=1a66c03#1a66c035de8db7092e578062d62729a93fe9c957"
-dependencies = [
- "ckb-jsonrpc-types",
- "ckb-traits",
- "ckb-types",
- "serde",
 ]
 
 [[package]]
@@ -446,20 +235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-pow"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cf952a3a1cac25e8d8c26d1a578e7256808f83594c7826e71b24b6114ee7ddb"
-dependencies = [
- "byteorder",
- "ckb-hash",
- "ckb-types",
- "eaglesong",
- "log 0.4.17",
- "serde",
-]
-
-[[package]]
 name = "ckb-rational"
 version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,79 +245,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "ckb-resource"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7eefc5c051e975acc95dcb74089502b0b23cb59a9b2c38b907a08677d87ec940"
-dependencies = [
- "ckb-system-scripts",
- "ckb-types",
- "includedir",
- "includedir_codegen",
- "phf",
- "serde",
- "walkdir",
-]
-
-[[package]]
-name = "ckb-script"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e052a3832a90f6b4be8d9545657f0a0eb27391d4654aadcafbd0b3e24834a96d"
-dependencies = [
- "byteorder",
- "ckb-chain-spec",
- "ckb-error",
- "ckb-hash",
- "ckb-traits",
- "ckb-types",
- "ckb-vm",
- "faster-hex 0.6.1",
- "serde",
-]
-
-[[package]]
 name = "ckb-standalone-types"
-version = "0.1.3"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acafe9a1a706e9704a3c37cdc05fddb84cf991fb0744df21e5a0d91e128163b8"
+checksum = "b5c776d70eb4f60a22a3180857646d77b2da8d33c0c4a063ad9f6610fc94609f"
 dependencies = [
- "blake2b-ref 0.3.1",
+ "blake2b-ref 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "cfg-if",
  "molecule",
 ]
 
 [[package]]
 name = "ckb-std"
-version = "0.14.0"
+version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef02519ff65a2326e0ce8d3b4920c7dedac28f79eee4d7aef3ce64fccb556710"
+checksum = "2a08518aa0fd4ce069d3ec80b63dcd3d6543ad3805ad1c0b4e1d8e4d38f8a9fc"
 dependencies = [
  "buddy-alloc",
  "cc",
  "ckb-standalone-types",
-]
-
-[[package]]
-name = "ckb-system-scripts"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa5c59063142de7a68cfad4449c6b3863563856219a2925dfb8c5f019ec2aa47"
-dependencies = [
- "blake2b-rs",
- "faster-hex 0.6.1",
- "includedir",
- "includedir_codegen",
- "phf",
-]
-
-[[package]]
-name = "ckb-traits"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c5fa4950994edb7efd35d035afc5f5f4739dd056f9c54ead62991c8f2f4f0fc"
-dependencies = [
- "ckb-types",
 ]
 
 [[package]]
@@ -565,105 +286,6 @@ dependencies = [
  "molecule",
  "numext-fixed-uint",
  "once_cell",
-]
-
-[[package]]
-name = "ckb-util"
-version = "0.108.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "050fcae575aa6bdb3d33197992da9ef7c8d7b3d5ad9be9bb702ebf211ed8f3d4"
-dependencies = [
- "linked-hash-map",
- "once_cell",
- "parking_lot",
- "regex 1.8.4",
-]
-
-[[package]]
-name = "ckb-vm"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1223acc8054ce96f91c5d99d4942898d0bdadd618c3b14f1acd3e67212991d8e"
-dependencies = [
- "byteorder",
- "bytes",
- "cc",
- "ckb-vm-definitions",
- "derive_more",
- "goblin 0.2.3",
- "goblin 0.4.0",
- "rand",
- "scroll",
- "serde",
-]
-
-[[package]]
-name = "ckb-vm-definitions"
-version = "0.22.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4af800ae2b6c54b70efa398dab015a09a52eeac2dd1ac3ad32c9bbe224974225"
-
-[[package]]
-name = "clap"
-version = "4.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9394150f5b4273a1763355bd1c2ec54cc5a2593f790587bcd6b2c947cfa9211"
-dependencies = [
- "clap_builder",
- "clap_derive",
- "once_cell",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a78fbdd3cc2914ddf37ba444114bc7765bbdcb55ec9cbe6fa054f0137400717"
-dependencies = [
- "anstream",
- "anstyle",
- "bitflags",
- "clap_lex",
- "strsim",
-]
-
-[[package]]
-name = "clap_derive"
-version = "4.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8cd2b2a819ad6eec39e8f1d6b53001af1e5469f8c177579cdaeb313115b825f"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn 2.0.22",
-]
-
-[[package]]
-name = "clap_lex"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2da6da31387c7e4ef160ffab6d5e7f00c42626fe39aea70a7b0f1773f7dd6c1b"
-
-[[package]]
-name = "colorchoice"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
-
-[[package]]
-name = "convert_case"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -697,71 +319,16 @@ version = "0.99.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fb810d30a7c1953f91334de7244731fc3f3c10d7fe163338a35b9f640960321"
 dependencies = [
- "convert_case",
  "proc-macro2",
  "quote",
- "rustc_version",
  "syn 1.0.109",
 ]
-
-[[package]]
-name = "eaglesong"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d978bd5d343e8ab9b5c0fc8d93ff9c602fdc96616ffff9c05ac7a155419b824"
-
-[[package]]
-name = "env_logger"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddf21e73e016298f5cb37d6ef8e8da8e39f91f9ec8b0df44b7deb16a9f8cd5b"
-dependencies = [
- "log 0.3.9",
- "regex 0.2.11",
-]
-
-[[package]]
-name = "errno"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bcfec3a70f97c962c307b2d2c56e358cf1d00b558d74262b5f929ee8cc7e73a"
-dependencies = [
- "errno-dragonfly",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "errno-dragonfly"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa68f1b12764fab894d2755d2518754e71b4fd80ecfb822714a1206c2aab39bf"
-dependencies = [
- "cc",
- "libc",
-]
-
-[[package]]
-name = "faster-hex"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "348138dd23e03bb0018caef99647fb1a5befec5ff4b501991de88f09854d4c28"
 
 [[package]]
 name = "faster-hex"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51e2ce894d53b295cf97b05685aa077950ff3e8541af83217fc720a6437169f8"
-
-[[package]]
-name = "flate2"
-version = "1.0.26"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b9429470923de8e8cbd4d2dc513535400b4b3fef0319fb5c4e1f520a7bef743"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
-]
 
 [[package]]
 name = "getrandom"
@@ -778,34 +345,12 @@ dependencies = [
 name = "global-registry"
 version = "0.1.0"
 dependencies = [
- "blake2b-rs",
+ "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
  "ckb-lock-common",
  "ckb-std",
  "hex",
- "log 0.4.17",
+ "log",
  "molecule",
-]
-
-[[package]]
-name = "goblin"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d20fd25aa456527ce4f544271ae4fea65d2eda4a6561ea56f39fb3ee4f7e3884"
-dependencies = [
- "log 0.4.17",
- "plain",
- "scroll",
-]
-
-[[package]]
-name = "goblin"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "532a09cd3df2c6bbfc795fb0434bff8f22255d1d07328180e918a2e6ce122d4d"
-dependencies = [
- "log 0.4.17",
- "plain",
- "scroll",
 ]
 
 [[package]]
@@ -818,87 +363,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "heck"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
-
-[[package]]
-name = "hermit-abi"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed44880c466736ef9a5c5b5facefb5ed0785676d0c02d612db14e54f0d84286"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
-
-[[package]]
-name = "includedir"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "afd126bd778c00c43a9dc76d1609a0894bf4222088088b2217ccc0ce9e816db7"
-dependencies = [
- "flate2",
- "phf",
-]
-
-[[package]]
-name = "includedir_codegen"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ac1500c9780957c9808c4ec3b94002f35aab01483833f5a8bce7dfb243e3148"
-dependencies = [
- "flate2",
- "phf_codegen",
- "walkdir",
-]
-
-[[package]]
-name = "io-lifetimes"
-version = "1.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys",
-]
-
-[[package]]
-name = "is-terminal"
-version = "0.4.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adcf93614601c8129ddf72e2d5633df827ba6551541c6d8c59520a371475be1f"
-dependencies = [
- "hermit-abi",
- "io-lifetimes",
- "rustix",
- "windows-sys",
-]
-
-[[package]]
-name = "itoa"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453ad9f582a441959e5f0d088b02ce04cfe8d51a8eaf077f12ac6d3e94164ca6"
-
-[[package]]
-name = "js-sys"
-version = "0.3.64"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5f195fe497f702db0f318b07fdd68edb16955aed830df8363d837542f8f935a"
-dependencies = [
- "wasm-bindgen",
-]
-
-[[package]]
-name = "lazy_static"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
@@ -907,50 +375,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 
 [[package]]
-name = "linked-hash-map"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.3.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
-
-[[package]]
 name = "lock-wrapper"
 version = "0.1.0"
 dependencies = [
- "blake2b-rs",
+ "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
  "ckb-combine-lock-types",
  "ckb-lock-common",
  "ckb-std",
  "hex",
- "log 0.4.17",
+ "log",
  "molecule",
-]
-
-[[package]]
-name = "lock_api"
-version = "0.4.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1cc9717a20b1bb222f333e6a92fd32f7d8a18ddc5a3191a11af45dcbf4dcd16"
-dependencies = [
- "autocfg",
- "scopeguard",
-]
-
-[[package]]
-name = "log"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
-dependencies = [
- "log 0.4.17",
 ]
 
 [[package]]
@@ -963,27 +397,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "memchr"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
-
-[[package]]
 name = "merkle-cbt"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "171d2f700835121c3b04ccf0880882987a050fd5c7ae88148abf537d33dd3a56"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "miniz_oxide"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7810e0be55b428ada41041c41f32c9f1a42817901b4ccf45fa3d4b6561e74c7"
-dependencies = [
- "adler",
 ]
 
 [[package]]
@@ -994,7 +413,7 @@ checksum = "edc8276c02a006bddad7d1c28c1a88f30421e1b5f0ba0ca96ceb8077c7d20c01"
 dependencies = [
  "bytes",
  "cfg-if",
- "faster-hex 0.6.1",
+ "faster-hex",
 ]
 
 [[package]]
@@ -1055,73 +474,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
 
 [[package]]
-name = "parking_lot"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3742b2c103b9f06bc9fff0a37ff4912935851bee6d36f3c02bcc755bcfec228f"
-dependencies = [
- "lock_api",
- "parking_lot_core",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93f00c865fe7cabf650081affecd3871070f26767e7b2070a3ffae14c654b447"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-targets",
-]
-
-[[package]]
-name = "phf"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3dfb61232e34fcb633f43d12c58f83c1df82962dcdfa565a4e866ffc17dafe12"
-dependencies = [
- "phf_shared",
-]
-
-[[package]]
-name = "phf_codegen"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbffee61585b0411840d3ece935cce9cb6321f01c45477d30066498cd5e1a815"
-dependencies = [
- "phf_generator",
- "phf_shared",
-]
-
-[[package]]
-name = "phf_generator"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17367f0cc86f2d25802b2c26ee58a7b23faeccf78a396094c13dced0d0182526"
-dependencies = [
- "phf_shared",
- "rand",
-]
-
-[[package]]
-name = "phf_shared"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c00cf8b9eafe68dde5e9eaa2cef8ee84a9336a47d566ec55ca16589633b65af7"
-dependencies = [
- "siphasher",
-]
-
-[[package]]
-name = "plain"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
 name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1156,7 +508,6 @@ dependencies = [
  "rand_chacha",
  "rand_core",
  "rand_hc",
- "rand_pcg",
 ]
 
 [[package]]
@@ -1188,151 +539,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_pcg"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
-dependencies = [
- "rand_core",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
-name = "regex"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9329abc99e39129fcceabd24cf5d85b4671ef7c29c50e972bc5afe32438ec384"
-dependencies = [
- "aho-corasick 0.6.10",
- "memchr",
- "regex-syntax 0.5.6",
- "thread_local",
- "utf8-ranges",
-]
-
-[[package]]
-name = "regex"
-version = "1.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0ab3ca65655bb1e41f2a8c8cd662eb4fb035e67c3f78da1d61dffe89d07300f"
-dependencies = [
- "aho-corasick 1.0.2",
- "memchr",
- "regex-syntax 0.7.2",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.5.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d707a4fa2637f2dca2ef9fd02225ec7661fe01a53623c1e6515b6916511f7a7"
-dependencies = [
- "ucd-util",
-]
-
-[[package]]
-name = "regex-syntax"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436b050e76ed2903236f032a59761c1eb99e1b0aead2c257922771dab1fc8c78"
-
-[[package]]
-name = "rustc_version"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa0f585226d2e68097d4f95d113b15b83a82e819ab25717ec0590d9584ef366"
-dependencies = [
- "semver",
-]
-
-[[package]]
-name = "rustix"
-version = "0.37.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b96e891d04aa506a6d1f318d2771bcb1c7dfda84e126660ace067c9b474bb2c0"
-dependencies = [
- "bitflags",
- "errno",
- "io-lifetimes",
- "libc",
- "linux-raw-sys",
- "windows-sys",
-]
-
-[[package]]
-name = "ryu"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f91339c0467de62360649f8d3e185ca8de4224ff281f66000de5eb2a77a79041"
-
-[[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
-name = "scopeguard"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
-
-[[package]]
-name = "scroll"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fda28d4b4830b807a8b43f7b0e6b5df875311b3e7621d84577188c175b6ec1ec"
-dependencies = [
- "scroll_derive",
-]
-
-[[package]]
-name = "scroll_derive"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aaaae8f38bb311444cfb7f1979af0bc9240d95795f75f9ceddf6a59b79ceffa0"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b1629c9c557ef9b293568b338dddfc8208c98a18c59d722a9d53f859d9c9b62"
-dependencies = [
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83080e2c2fc1006e625be82e5d1eb6a43b7fd9578b617fcc55814daf286bba4b"
-dependencies = [
- "cc",
-]
-
-[[package]]
-name = "semver"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bebd363326d05ec3e2f532ab7660680f3b02130d780c299bca73469d521bc0ed"
-
-[[package]]
 name = "serde"
 version = "1.0.164"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1351,44 +557,6 @@ dependencies = [
  "quote",
  "syn 2.0.22",
 ]
-
-[[package]]
-name = "serde_json"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "46266871c240a00b8f503b877622fe33430b3c7d963bdc0f2adc511e54a1eae3"
-dependencies = [
- "itoa",
- "ryu",
- "serde",
-]
-
-[[package]]
-name = "serde_plain"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6018081315db179d0ce57b1fe4b62a12a0028c9cf9bbef868c9cf477b3c34ae"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "siphasher"
-version = "0.3.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd3e3206899af3f8b12af284fafc038cc1dc2b41d1b89dd17297221c5d225de"
-
-[[package]]
-name = "smallvec"
-version = "1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a507befe795404456341dfab10cef66ead4c041f62b8b11bbb92bffe5d0953e0"
-
-[[package]]
-name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -1433,116 +601,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "thread_local"
-version = "0.3.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
-dependencies = [
- "lazy_static",
-]
-
-[[package]]
-name = "toml"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4f7f0dd8d50a853a531c426359045b1998f04219d88799810762cd4ad314234"
-dependencies = [
- "serde",
-]
-
-[[package]]
-name = "ucd-util"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd2fc5d32b590614af8b0a20d837f32eca055edd0bbead59a9cfe80858be003"
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15811caf2415fb889178633e7724bad2509101cde276048e013b9def5e51fa0"
 
 [[package]]
-name = "utf8-ranges"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcfc827f90e53a02eaef5e535ee14266c1d569214c6aa70133a624d8a3164ba"
-
-[[package]]
-name = "utf8parse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
-
-[[package]]
-name = "walkdir"
-version = "2.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36df944cda56c7d8d8b7496af378e6b16de9284591917d307c9b4d313c44e698"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.9.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7706a72ab36d8cb1f80ffbf0e071533974a60d0a308d01a5d0375bf60499a342"
-dependencies = [
- "cfg-if",
- "wasm-bindgen-macro",
-]
-
-[[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ef2b6d3c510e9625e5fe6f509ab07d66a760f0885d858736483c32ed7809abd"
-dependencies = [
- "bumpalo",
- "log 0.4.17",
- "once_cell",
- "proc-macro2",
- "quote",
- "syn 2.0.22",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dee495e55982a3bd48105a7b947fd2a9b4a8ae3010041b9e0faab3f9cd028f1d"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.22",
- "wasm-bindgen-backend",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.87"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca6ad05a4870b2bf5fe995117d3728437bd27d7cd5f06f13c17443ef369775a1"
 
 [[package]]
 name = "winapi"
@@ -1561,82 +629,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
-name = "winapi-util"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70ec6ce85bb158151cae5e5c87f95a8e97d2c0c4b001223f33a334e3ce5de178"
-dependencies = [
- "winapi",
-]
-
-[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
-
-[[package]]
-name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b1eb6f0cd7c80c79759c929114ef071b87354ce476d9d94271031c0497adfd5"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91ae572e1b79dba883e0d315474df7305d12f569b400fcf90581b06062f7e1bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2ef27e0d7bdfcfc7b868b317c1d32c641a6fe4629c171b8928c7b08d98d7cf3"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "622a1962a7db830d6fd0a69683c80a18fda201879f0f447f065a3b7467daa241"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4542c6e364ce21bf45d69fdd2a8e455fa38d316158cfd43b3ac1c5b1b19f8e00"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca2b8a661f7628cbd23440e50b05d705db3686f894fc9580820623656af974b1"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7896dbc1f41e08872e9d5e8f8baa8fdd2677f29468c4e156210174edc7f7b953"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,11 +27,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "294d17c72e0ba59fad763caa112368d0672083779cdebbb97164f4bb4c1e339a"
 
 [[package]]
-name = "blake2b-ref"
-version = "0.3.1"
-source = "git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48#f1efc4872d67a8d4c4a57d2d0e16f8b5e53724b9"
-
-[[package]]
 name = "blake2b-rs"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,7 +103,7 @@ dependencies = [
 name = "ckb-combine-lock"
 version = "0.1.0"
 dependencies = [
- "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
+ "blake2b-ref 0.3.1",
  "ckb-combine-lock-types",
  "ckb-lock-common",
  "ckb-std",
@@ -186,7 +181,7 @@ dependencies = [
 name = "ckb-lock-common"
 version = "0.1.0"
 dependencies = [
- "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
+ "blake2b-ref 0.3.1",
  "ckb-combine-lock-types",
  "ckb-std",
  "hex",
@@ -250,7 +245,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5c776d70eb4f60a22a3180857646d77b2da8d33c0c4a063ad9f6610fc94609f"
 dependencies = [
- "blake2b-ref 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "blake2b-ref 0.3.1",
  "cfg-if",
  "molecule",
 ]
@@ -345,7 +340,7 @@ dependencies = [
 name = "global-registry"
 version = "0.1.0"
 dependencies = [
- "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
+ "blake2b-ref 0.3.1",
  "ckb-lock-common",
  "ckb-std",
  "hex",
@@ -378,7 +373,7 @@ checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
 name = "lock-wrapper"
 version = "0.1.0"
 dependencies = [
- "blake2b-ref 0.3.1 (git+https://github.com/jjyr/blake2b-ref.rs.git?rev=f1efc48)",
+ "blake2b-ref 0.3.1",
  "ckb-combine-lock-types",
  "ckb-lock-common",
  "ckb-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/types", "ckb-debugger-tests", "contracts/ckb-combine-lock", "contracts/child-script-example", "contracts/child-script-always-success", "contracts/child-script-always-failure", "contracts/global-registry", "contracts/lock-wrapper"]
+members = ["crates/types", "contracts/ckb-combine-lock", "contracts/child-script-example", "contracts/child-script-always-success", "contracts/child-script-always-failure", "contracts/global-registry", "contracts/lock-wrapper"]
 
 [profile.release]
 overflow-checks = true

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 MOLC := moleculec
 
 all:
-	capsule build --release
+	cargo build --release --target=riscv64imac-unknown-none-elf
 
 mol: ckb-lock-common/src/generated/blockchain.rs
 	${MOLC} --language rust --schema-file crates/types/combine_lock.mol | rustfmt > crates/types/src/combine_lock.rs
@@ -14,7 +14,7 @@ mol: ckb-lock-common/src/generated/blockchain.rs
 
 ci:
 	cd tests/global-registry && cargo test && cd ../..
-	capsule build --release
+	cargo build --release --target=riscv64imac-unknown-none-elf
 	make -C ckb-debugger-tests all
 
 # this is optional
@@ -23,10 +23,8 @@ install-moleculec:
 	cargo install --force --version "0.7.3" "moleculec"
 
 install:
+	rustup target add riscv64imac-unknown-none-elf
 	wget 'https://github.com/XuJiandong/ckb-standalone-debugger/releases/download/ckb2023-0621/ckb-debugger-linux-x64.tar.gz'
 	tar zxvf ckb-debugger-linux-x64.tar.gz
 	mv ckb-debugger ~/.cargo/bin/ckb-debugger-2023
-	cargo install cross --git https://github.com/cross-rs/cross
-	wget 'https://github.com/nervosnetwork/capsule/releases/download/v0.10.0/capsule_v0.10.0_x86_64-linux.tar.gz'
-	tar xzvf capsule_v0.10.0_x86_64-linux.tar.gz
-	mv capsule_v0.10.0_x86_64-linux/capsule ~/.cargo/bin
+	wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && sudo ./llvm.sh 16 && rm llvm.sh

--- a/README.md
+++ b/README.md
@@ -4,15 +4,21 @@ Design draft https://cryptape.notion.site/Combine-Lock-Script-e49f1f2de7504e8da1
 
 Note: This is a draft design and PoC implementation. The design could change drastically in future iterations.
 
+### Requirements
+- Rust 1.69 or above
+- Clang 16 or above
+- ckb-debugger
+
 ### How to Build
 Install build tools:
 ``` sh
 make install
 ```
+It will install ckb-debugger, clang-16 and Rust target(riscv64imac-unknown-none-elf). 
 
 Build contracts:
 ``` sh
-capsule build --release
+cargo build --release --target=riscv64imac-unknown-none-elf
 ```
 
 Run tests:

--- a/ckb-debugger-tests/Cargo.lock
+++ b/ckb-debugger-tests/Cargo.lock
@@ -180,6 +180,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "ckb-combine-lock-types"
+version = "0.1.0"
+dependencies = [
+ "ckb-types",
+ "molecule",
+]
+
+[[package]]
 name = "ckb-constant"
 version = "0.108.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -237,6 +245,7 @@ name = "ckb-debugger-tests"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "ckb-combine-lock-types",
  "ckb-crypto",
  "ckb-debugger-api",
  "ckb-hash",

--- a/ckb-debugger-tests/Cargo.toml
+++ b/ckb-debugger-tests/Cargo.toml
@@ -1,3 +1,5 @@
+[workspace]
+
 [package]
 edition = "2021"
 name = "ckb-debugger-tests"

--- a/ckb-debugger-tests/templates/child-script-multi-inputs.json
+++ b/ckb-debugger-tests/templates/child-script-multi-inputs.json
@@ -49,7 +49,7 @@
           },
           "type": "{{ def_type child-script-example }}"
         },
-        "data": "0x{{ data ../../build/release/child-script-example }}"
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-example }}"
       },
       {
         "output": {

--- a/ckb-debugger-tests/templates/child-script-success.json
+++ b/ckb-debugger-tests/templates/child-script-success.json
@@ -25,7 +25,7 @@
           },
           "type": "{{ def_type child-script-example }}"
         },
-        "data": "0x{{ data ../../build/release/child-script-example }}"
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-example }}"
       },
       {
         "output": {

--- a/ckb-debugger-tests/templates/cl-child-script.json
+++ b/ckb-debugger-tests/templates/cl-child-script.json
@@ -37,7 +37,7 @@
           },
           "type": "{{ def_type child-script-example }}"
         },
-        "data": "0x{{ data ../../build/release/child-script-example }}"
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-example }}"
       },
       {
         "output": {

--- a/ckb-debugger-tests/templates/gr-child-script.json
+++ b/ckb-debugger-tests/templates/gr-child-script.json
@@ -37,7 +37,7 @@
           },
           "type": "{{ def_type child-script-example }}"
         },
-        "data": "0x{{ data ../../build/release/child-script-example }}"
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-example }}"
       },
       {
         "output": {

--- a/ckb-debugger-tests/templates/gr-insert.json
+++ b/ckb-debugger-tests/templates/gr-insert.json
@@ -64,7 +64,7 @@
           },
           "type": "{{ def_type child-script-example }}"
         },
-        "data": "0x{{ data ../../build/release/child-script-example }}"
+        "data": "0x{{ data ../../target/riscv64imac-unknown-none-elf/release/child-script-example }}"
       },
       {
         "output": {

--- a/ckb-lock-common/Cargo.toml
+++ b/ckb-lock-common/Cargo.toml
@@ -9,10 +9,10 @@ default = ["log"]
 log = []
 
 [dependencies]
-blake2b-rs = "0.2.0"
+blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
 molecule = { version = "0.7.3", default-features = false }
 ckb-combine-lock-types = { path = "../crates/types" }
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 hex = { version = "0.4.3", default-features = false, features = ["alloc"]}
 log = { version = "0.4.17", default-features = false }
 molecule2 = { git = "https://github.com/XuJiandong/moleculec-c2.git", rev = "4c97e75" }

--- a/ckb-lock-common/Cargo.toml
+++ b/ckb-lock-common/Cargo.toml
@@ -9,7 +9,7 @@ default = ["log"]
 log = []
 
 [dependencies]
-blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
+blake2b-ref = "0.3.1"
 molecule = { version = "0.7.3", default-features = false }
 ckb-combine-lock-types = { path = "../crates/types" }
 ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }

--- a/ckb-lock-common/src/blake2b.rs
+++ b/ckb-lock-common/src/blake2b.rs
@@ -1,4 +1,4 @@
-pub use blake2b_rs::{Blake2b, Blake2bBuilder};
+pub use blake2b_ref::{Blake2b, Blake2bBuilder};
 
 pub const CKB_PERSONALIZATION: &[u8] = b"ckb-default-hash";
 

--- a/ckb-lock-common/src/error.rs
+++ b/ckb-lock-common/src/error.rs
@@ -37,6 +37,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }

--- a/ckb-lock-common/src/generate_sighash_all.rs
+++ b/ckb-lock-common/src/generate_sighash_all.rs
@@ -3,7 +3,7 @@ use crate::error::Error;
 use crate::intersection::get_intersection;
 use crate::simple_cursor::{get_witness_len, SimpleCursor};
 use alloc::{vec, vec::Vec};
-use blake2b_rs::Blake2b;
+use blake2b_ref::Blake2b;
 use ckb_std::ckb_constants::{InputField, Source};
 use ckb_std::high_level::load_tx_hash;
 use ckb_std::syscalls::{load_input_by_field, load_witness, SysError};

--- a/contracts/child-script-always-failure/Cargo.toml
+++ b/contracts/child-script-always-failure/Cargo.toml
@@ -6,4 +6,4 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }

--- a/contracts/child-script-always-failure/src/error.rs
+++ b/contracts/child-script-always-failure/src/error.rs
@@ -20,6 +20,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }

--- a/contracts/child-script-always-success/Cargo.toml
+++ b/contracts/child-script-always-success/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 
 [dependencies]
 ckb-lock-common = { path = "../../ckb-lock-common" }
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 log = { version = "0.4.17", default-features = false }

--- a/contracts/child-script-always-success/src/error.rs
+++ b/contracts/child-script-always-success/src/error.rs
@@ -18,6 +18,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }

--- a/contracts/child-script-example/Cargo.toml
+++ b/contracts/child-script-example/Cargo.toml
@@ -9,7 +9,7 @@ default = ["log"]
 log = ["ckb-lock-common/log"]
 
 [dependencies]
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 ckb-lock-common = { path = "../../ckb-lock-common" }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }

--- a/contracts/child-script-example/src/error.rs
+++ b/contracts/child-script-example/src/error.rs
@@ -25,6 +25,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }

--- a/contracts/ckb-combine-lock/Cargo.toml
+++ b/contracts/ckb-combine-lock/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
+blake2b-ref = "0.3.1"
 ckb-lock-common = { path = "../../ckb-lock-common" }
 ckb-combine-lock-types = { path = "../../crates/types" }
 ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }

--- a/contracts/ckb-combine-lock/Cargo.toml
+++ b/contracts/ckb-combine-lock/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2b-rs = "0.2.0"
+blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
 ckb-lock-common = { path = "../../ckb-lock-common" }
 ckb-combine-lock-types = { path = "../../crates/types" }
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 molecule = { version = "0.7.3", default-features = false }

--- a/contracts/ckb-combine-lock/src/error.rs
+++ b/contracts/ckb-combine-lock/src/error.rs
@@ -29,6 +29,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }

--- a/contracts/global-registry/Cargo.toml
+++ b/contracts/global-registry/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
+blake2b-ref = "0.3.1"
 ckb-lock-common = { path = "../../ckb-lock-common" }
 ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }

--- a/contracts/global-registry/Cargo.toml
+++ b/contracts/global-registry/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2b-rs = "0.2.0"
+blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
 ckb-lock-common = { path = "../../ckb-lock-common" }
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 molecule = { version = "0.7.3", default-features = false }

--- a/contracts/global-registry/src/error.rs
+++ b/contracts/global-registry/src/error.rs
@@ -31,6 +31,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }

--- a/contracts/lock-wrapper/Cargo.toml
+++ b/contracts/lock-wrapper/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
+blake2b-ref = "0.3.1"
 ckb-lock-common = { path = "../../ckb-lock-common" }
 ckb-combine-lock-types = { path = "../../crates/types" }
 ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }

--- a/contracts/lock-wrapper/Cargo.toml
+++ b/contracts/lock-wrapper/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-blake2b-rs = "0.2.0"
+blake2b-ref = { git = "https://github.com/jjyr/blake2b-ref.rs.git", rev = "f1efc48" }
 ckb-lock-common = { path = "../../ckb-lock-common" }
 ckb-combine-lock-types = { path = "../../crates/types" }
-ckb-std = { version = "0.14.0", features = ["ckb2023"] }
+ckb-std = { version = "0.14.3", features = ["ckb2023", "build-with-clang"] }
 hex = { version = "0.4", default-features = false, features = ["alloc"] }
 log = { version = "0.4.17", default-features = false }
 molecule = { version = "0.7.3", default-features = false }

--- a/contracts/lock-wrapper/src/error.rs
+++ b/contracts/lock-wrapper/src/error.rs
@@ -30,6 +30,7 @@ impl From<SysError> for Error {
             LengthNotEnough(_) => Self::LengthNotEnough,
             Encoding => Self::Encoding,
             Unknown(err_code) => panic!("unexpected sys error {}", err_code),
+            _ => panic!("unexpected sys error"),
         }
     }
 }


### PR DESCRIPTION
With following native toolchains:
clang-16
Rust 1.69
